### PR TITLE
Optimize upsert process and clean error logs

### DIFF
--- a/omni/pro/exceptions.py
+++ b/omni/pro/exceptions.py
@@ -41,7 +41,7 @@ def handle_error(service_model: str, service_method: str, logger, error: Excepti
     error_handlers = {
         IntegrityError: (
             f"{service_model} {service_method} integrity error",
-            lambda error: f"pgerror: {error.orig.pgerror}",
+            lambda error: "pgerror: {0}".format(error.orig.pgerror.split("DETAIL:")[0]),
         ),
         ValidationError: (
             f"{service_model} {service_method} validation error",

--- a/omni/pro/import_export.py
+++ b/omni/pro/import_export.py
@@ -162,7 +162,7 @@ class BatchUpsert(ImportExportBase):
         data (dict): The data to be upserted.
         Returns: The result of the NoSQL upsert operation.
         """
-        self.context.db_manager.batch_upsert(model, data)
+        return self.context.db_manager.batch_upsert(model, data)
 
     def upsert_data_sql(self, model, data):
         """
@@ -172,4 +172,4 @@ class BatchUpsert(ImportExportBase):
         data (dict): The data to be upserted.
         Returns: The result of the SQL upsert operation.
         """
-        self.context.pg_manager.batch_upsert(model, self.context.pg_manager.Session, data)
+        return self.context.pg_manager.batch_upsert(model, self.context.pg_manager.Session, data)


### PR DESCRIPTION
Refactored the upsert workflow in PostgresDatabaseManager to accumulate objects in a list and perform a bulk save, improving efficiency. A set-differential approach is used post-commit to return records upserted in the current batch, excluding duplicates, ensuring accurate results. Error log messages for integrity errors are now stripped of extraneous "DETAIL" information for better readability. Ensured consistency by returning the upsert results in the ImportExport module's BatchUpsert class.