### PR TITLE
Set default filterability for fields

### DIFF
--- a/omni/pro/descriptor.py
+++ b/omni/pro/descriptor.py
@@ -64,6 +64,8 @@ class Descriptor(object):
 
             if hasattr(field, "is_filterable"):
                 field_info["is_filterable"] = field.is_filterable
+            else:
+                field_info["is_filterable"] = True
 
             # If the field is an EmbeddedDocumentField or ReferenceField, recurse into its fields
             if isinstance(field, EmbeddedDocumentField) or isinstance(field, ReferenceField):


### PR DESCRIPTION
Adjust the descriptor logic to default the 'is_filterable' attribute to True for fields lacking this property, ensuring consistent filter behavior across the application. This change caters to the assumption that most fields are intended to be filterable unless explicitly set otherwise.