### PR TITLE
Removed obsolete 'is_replic' field from descriptor output

### DIFF
--- a/omni/pro/descriptor.py
+++ b/omni/pro/descriptor.py
@@ -101,7 +101,6 @@ class Descriptor(object):
                 "class_name": f"{model.__module__}.{model.__name__}",
                 "code": model._meta.get("collection") or model.__name__.lower(),
                 "fields": fields,
-                "is_replic": model.__is_replic_table__,
             }
 
         else:  # This is a recursive call


### PR DESCRIPTION
Dropped an outdated field from the Descriptor class's output generation, which referenced an unused 'is_replic_table__' attribute in models. The cleanup supports the ongoing deprecation of legacy database replication functionality and streamlines the descriptor structure.