### PR TITLE
feat: Refactor manifest loading and validation

### DIFF
--- a/omni/pro/validators.py
+++ b/omni/pro/validators.py
@@ -120,15 +120,16 @@ class ObjectIdField(fields.Field):
 class MicroServiceValidator(Context, Schema):
     name = fields.String(required=True)
     code = fields.String(required=True)
-    tenant_code = fields.String(required=True)
+    sumary = fields.String(required=True)
     description = fields.String(required=True)
     version = fields.String(required=True)
     author = fields.String(required=True)
-    summary = fields.String(required=True)
     category = fields.String(required=True)
     depends = fields.List(fields.String())
     data = fields.List(fields.String())
 
+
+class MicroServicePathValidator(MicroServiceValidator):
     def __init__(self, base_app, micro_data, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.base_app = base_app

--- a/omni/pro/validators.py
+++ b/omni/pro/validators.py
@@ -129,6 +129,10 @@ class MicroServiceValidator(Context, Schema):
     data = fields.List(fields.String())
 
 
+class MicroServiceValidatorData(MicroServiceValidator):
+    data = fields.List(fields.Dict())
+
+
 class MicroServicePathValidator(MicroServiceValidator):
     def __init__(self, base_app, micro_data, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This commit refactors the `LoadData` class by moving the manifest loading and validation logic to a separate `Manifest` class. The `Manifest` class now has methods to retrieve the manifest data from the `__manifest__.py` file, validate the manifest data using the `MicroServicePathValidator`, and load the manifest into the system using the `ManifestRPCFunction`. This separation of concerns improves code organization and readability.