### PR TITLE
Refactor peewee import in topology module

### DIFF
--- a/omni/pro/topology.py
+++ b/omni/pro/topology.py
@@ -3,11 +3,10 @@ import inspect
 import pkgutil
 
 import networkx as nx
-import peewee
 from mongoengine.document import Document
 from omni.pro.logger import configure_logger
 from omni.pro.models.base import BaseAuditEmbeddedDocument, BaseDocument, BaseModel
-from peewee import ForeignKeyField
+
 
 logger = configure_logger(__name__)
 
@@ -17,6 +16,8 @@ class Topology(object):
         self.path_models = importlib.import_module("models")
 
     def sort_models_topologically(self, models: list) -> list:
+        from peewee import ForeignKeyField
+
         graph = nx.DiGraph()
 
         # Agrega todos los modelos como nodos en el gráfico.


### PR DESCRIPTION
Optimized the import of the ForeignKeyField from peewee by moving it inside the `sort_models_topologically` method. This change reduces the scope of the import to where it's actually used, potentially improving memory usage and startup time of the topology processing.