### PR TITLE
Set default MongoDB connection options

### DIFF
--- a/omni/pro/database.py
+++ b/omni/pro/database.py
@@ -190,13 +190,12 @@ class MongoConnection(object):
     """
 
     def __init__(self, host, port, db, username, password, complement):
-        self.host = (
-            f"mongodb://{username}:{password}@{host}:{port}/?{'&'.join([f'{k}={v}' for (k, v) in complement.items()])}"
-        )
+        self.host = f"mongodb://{username}:{password}@{host}:{port}/?retryWrites=true&replicaSet=rs0&authSource=admin"
         self.port = port
         self.username = username
         self.password = password
         self.db = db
+        self.complement = complement
 
     def connect(self):
         """Connects to the MongoDB database.
@@ -209,6 +208,9 @@ class MongoConnection(object):
             username=self.username,
             password=self.password,
             host=self.host,
+            authentication_source="admin",
+            ssl=True,
+            ssl_ca_certs=self.complement.get("tlsCAFile"),
         )
         return self.connection
 


### PR DESCRIPTION
Refactored the MongoDB URI construction to use a preset configuration including enabling retries on writes, specifying a replica set, and using an admin authentication source. Added SSL connection with a configurable CA certificate as part of a security enhancement to enforce encrypted communication with the database. The `complement` dict is now stored but individual settings are configured statically within the connection string to promote consistent connection behavior across different environments.

Resolves: #12345