### PR TITLE
Refactor MongoConnection host string construction

### DIFF
--- a/omni/pro/database.py
+++ b/omni/pro/database.py
@@ -190,12 +190,13 @@ class MongoConnection(object):
     """
 
     def __init__(self, host, port, db, username, password, complement):
-        self.host = f"mongodb://{username}:{password}@{host}:{port}/?retryWrites=true&replicaSet=rs0&authSource=admin"
+        self.host = (
+            f"mongodb://{username}:{password}@{host}:{port}/?{'&'.join([f'{k}={v}' for (k, v) in complement.items()])}"
+        )
         self.port = port
         self.username = username
         self.password = password
         self.db = db
-        self.complement = complement
 
     def connect(self):
         """Connects to the MongoDB database.
@@ -208,9 +209,6 @@ class MongoConnection(object):
             username=self.username,
             password=self.password,
             host=self.host,
-            authentication_source="admin",
-            ssl=True,
-            ssl_ca_certs=self.complement.get("tlsCAFile"),
         )
         return self.connection
 


### PR DESCRIPTION
Updated MongoConnection's constructor to dynamically construct the MongoDB host connection string using a dictionary of parameters. This change allows for more flexible configuration by adding custom connection parameters without hardcoding them. It also cleans up the MongoConnection class by removing the static assignment of 'complement' and associated SSL options, allowing for broader use cases and easier maintenance. The database connection method is simplified by relying on the host string for all configurations.

# Please note, no issue references were provided to include in this message.