### PR TITLE
Enhance Redis key fetching over SSL

### DIFF
--- a/omni/pro/database/redis.py
+++ b/omni/pro/database/redis.py
@@ -116,7 +116,15 @@ class RedisManager(object):
 
     def get_tenant_codes(self, pattern="*") -> list:
         with self.get_connection() as rc:
-            return rc.keys(pattern=pattern)
+            if Config.REDIS_SSL is False:
+                return rc.keys(pattern=pattern)
+
+            cursor = "0"
+            keys = []
+            while cursor != 0:
+                cursor, next_keys = rc.scan(cursor=cursor, match=pattern)
+                keys.extend(next_keys)
+            return keys
 
     def get_user_admin(self, tenant):
         tenant_obj = self.get_json(tenant)


### PR DESCRIPTION
Updated the method for retrieving tenant keys from Redis to support SSL connections. Previously, the `keys` command was used, which is not optimal with SSL due to potential performance issues. Now, when SSL is enabled, the method uses `scan` in a loop to incrementally retrieve keys, which is more efficient and better suited for encrypted connections. This change ensures reliable performance for deployments using Redis with SSL.

Refs #4567