### PR TITLE
Fixed boolean literals in database filter parsing

### DIFF
--- a/omni/pro/database/postgres.py
+++ b/omni/pro/database/postgres.py
@@ -201,7 +201,8 @@ class PostgresDatabaseManager(SessionManager):
 
         if filter.ListFields():
             # Uso de la clase
-            expression = ast.literal_eval(filter.filter)  # Tu expresión en notación polaca inversa
+            str_filter = filter.filter.replace("true", "True").replace("false", "False").replace("__", ".")
+            expression = ast.literal_eval(str_filter)  # Tu expresión en notación polaca inversa
             # converter = PolishNotationToSQLAlchemy(model, expression)
             # filter_condition, aliases = converter.convert()
 


### PR DESCRIPTION
Adjusted the filter parsing logic in the PostgresDatabaseManager to replace occurrences of 'true' and 'false' with their Python boolean counterparts 'True' and 'False' as well as replacing '__' with '.'. This ensures proper evaluation of the filter expressions in Python's abstract syntax tree (AST) and maintains compatibility with PostgreSQL's boolean literals.