### PR TITLE
feat(check_migration): manejar excepciones en la creación de revisiones

### DIFF
--- a/omni/pro/check_migration.py
+++ b/omni/pro/check_migration.py
@@ -99,11 +99,16 @@ class AlembicMigrateCheck(object):
             return latest_version.version_num if latest_version else None
 
     def apply_revision(self, message="auto-generated revision") -> Script:
-        # Usa la librería alembic para aplicar la revisión
-        # dar formato al mensaje concatenando la fecha y hora en formato ISO
+        # Formato del mensaje con fecha y hora en formato ISO
         message = f"{message} {datetime.now().isoformat()}"
-        new_revision = command.revision(self.alembic_config, autogenerate=True, message=message)
-        return new_revision
+        try:
+            # Intenta crear la revisión de Alembic
+            new_revision = command.revision(self.alembic_config, autogenerate=True, message=message)
+            return new_revision
+        except Exception as e:
+            # Registra el error específico si no se puede encontrar la tabla referenciada
+            logger.error(f"Failed to create revision due to a missing referenced table: {e}")
+            raise e
 
     def no_changes_detected(self, script: Script) -> bool:
         code = inspect_ast.getsource(script.module.upgrade)


### PR DESCRIPTION
Se agregó un bloque try-except en el método `apply_revision` para manejar excepciones al crear revisiones de Alembic. Ahora se registra un mensaje de error específico si no se puede encontrar la tabla referenciada.

Refs: develop