### PR TITLE
feat(base): add ORM session refresh after flush in base model

### DIFF
--- a/omni/pro/models/base.py
+++ b/omni/pro/models/base.py
@@ -259,6 +259,7 @@ class Base:
         instance.update(session)
         """
         session.flush()
+        session.refresh(self)
 
     def delete(self, session):
         """


### PR DESCRIPTION
This commit introduces an update to the base model in the `saas-ms-library` project, ensuring that the ORM session is refreshed to include the latest state of the instance after a flush operation. This enhancement is crucial for maintaining data consistency and can prevent potential issues where the state of the object in memory is out of sync with the database after changes are made within a session.

# The change is made in the `omni/pro/models/base.py` file, where a single line has been added to invoke the `session.refresh` method on the current instance following the `session.flush` call. This will help ensure that any subsequent operations on the instance within the same session will work with the most up-to-date information.