### PR TITLE
feat: Update AWSS3Client to generate presigned URLs for uploaded objects

### DIFF
--- a/omni/pro/aws/s3.py
+++ b/omni/pro/aws/s3.py
@@ -1,4 +1,5 @@
 from botocore.config import Config
+from botocore.exceptions import NoCredentialsError, PartialCredentialsError
 from omni.pro.aws.client import AWSClient
 
 
@@ -103,10 +104,17 @@ class AWSS3Client(AWSClient):
 
         :raises boto3.exceptions.S3UploadFailedError: If the upload to S3 fails.
         """
-        binary_content = int(file_content, 2).to_bytes((len(file_content) + 7) // 8, byteorder="big")
-        self._client.put_object(Bucket=self.bucket_name, Key=object_name, Body=binary_content, ContentType=content_type)
-        url = f"https://{self.bucket_name}.s3.amazonaws.com/{object_name}"
-        return url
+        try:
+            binary_content = int(file_content, 2).to_bytes((len(file_content) + 7) // 8, byteorder="big")
+            self._client.put_object(
+                Bucket=self.bucket_name, Key=object_name, Body=binary_content, ContentType=content_type
+            )
+            url = self._client.generate_presigned_url(
+                "get_object", Params={"Bucket": self.bucket_name, "Key": object_name}
+            )
+            return url
+        except (NoCredentialsError, PartialCredentialsError) as e:
+            raise e
 
     def get_object_metadata(self, object_name):
         """


### PR DESCRIPTION
The code changes in `s3.py` modify the `upload_object` method in the `AWSS3Client` class. The method now generates a presigned URL for the uploaded object using the `generate_presigned_url` function from the `botocore.client` module. This allows for secure access to the uploaded object without requiring additional authentication. The recent user commits and repository commits indicate a focus on improving the AWS S3 functionality and handling different types of webhooks.