### PR TITLE
feat: Add no_content_error method to MessageResponse

### DIFF
--- a/omni/pro/response.py
+++ b/omni/pro/response.py
@@ -216,7 +216,7 @@ class MessageResponse(object):
             **kwargs,
         )
 
-    def no_content_error(self, message: str, **kwargs):
+    def no_content_response(self, message: str, **kwargs):
         return self.response(
             success=True,
             message=message,

--- a/omni/pro/response.py
+++ b/omni/pro/response.py
@@ -215,3 +215,12 @@ class MessageResponse(object):
             message_code=MessageCode.OPERATION_ERROR,
             **kwargs,
         )
+
+    def no_content_error(self, message: str, **kwargs):
+        return self.response(
+            success=True,
+            message=message,
+            status_code=HTTPStatus.NO_CONTENT,
+            message_code=MessageCode.RESOURCE_NOT_FOUND,
+            **kwargs,
+        )


### PR DESCRIPTION
The code changes in `response.py` include adding a `no_content_error` method to the `MessageResponse` class. This method allows for returning a success response with a specific message code and status code of 204 (NO_CONTENT). The recent user commits and repository commits indicate a focus on adding new features and improving the codebase.