### PR TITLE
refactor: Update comparison operators in PostgreSQL and MongoDB

### DIFF
--- a/omni/pro/database/mongo.py
+++ b/omni/pro/database/mongo.py
@@ -635,8 +635,12 @@ class PolishNotationToMongoDB:
             "in": "$in",
             "nin": "$nin",
             "!=": "$ne",
+            "not_like": "$not",
             "!like": "$not",
+            "not_ilike": "$not",
+            "!ilike": "$not",
             "like": "$regex",
+            "ilike": "$regex",
         }
 
     def is_logical_operator(self, token):
@@ -665,9 +669,9 @@ class PolishNotationToMongoDB:
                 field, old_operator, value = token
                 if old_operator in self.operators_comparison:
                     options = {}
-                    if old_operator == "like":
+                    if old_operator in ["like", "ilike"]:
                         options = {"$options": "i"}
-                    elif old_operator == "!like":
+                    elif old_operator in ["not_like", "!like", "not_ilike", "!ilike"]:
                         options = {
                             self.operators_comparison[old_operator]: {
                                 "$regex": value,


### PR DESCRIPTION
# [NVOMS-2707](https://omnipro.atlassian.net/browse/NVOMS-2707) - Filtros de Models

## ref [NVOMS-2707](https://omnipro.atlassian.net/browse/NVOMS-2707)

## Descripción
Los cambios de código en `mongo.py` y `postgres.py` actualizan los operadores de comparación utilizados en las clases PolishNotationToMongoDB y PostgresDatabaseManager. Esto incluye añadir soporte para nuevos operadores como `not_like`, `not_ilike`, `!like`, y `!ilike`, así como actualizar el comportamiento de operadores existentes como `like` y `ilike`. Estos cambios mejoran la flexibilidad y precisión de las operaciones de consulta en ambas bases de datos.

Se han realizado modificaciones en los archivos `omni/pro/database/mongo.py` y `omni/pro/database/postgres.py` para actualizar y estandarizar la forma en que se manejan los operadores de comparación en consultas, especialmente los operadores de tipo "like" y sus variantes negadas.

## Cambios
- **mongo.py**
  - **Nuevos operadores de comparación:**
    - Se añadieron las claves `not_like`, `not_ilike` y sus variantes cortas `!like`, `!ilike` al diccionario de operadores de comparación.
  - **Uso de operadores de comparación en `convert`:**
    - Modificación del manejo de operadores `like` e `ilike` para incluir las nociones de insensibilidad a mayúsculas y minúsculas.
    - Ajuste para tratar correctamente las expresiones `not_like`, `!like`, `not_ilike` y `!ilike`.

- **postgres.py**
  - **Importaciones duplicadas:**
    - Se eliminó una línea duplicada de importación (`WebhookHandler`).
  - **Nuevos operadores en `get_sqlalchemy_operator`:**
    - Se añadieron operadores `not_like`, `not_ilike` y sus variantes cortas `!like`, `!ilike` al mapeo de operadores de SQLAlchemy.
  - **Manejo de operadores en `parse_expression`:**
    - Ajuste de operador `like` para utilizar `ilike_op` de SQLAlchemy.
    - Inclusión de operadores `not_like`, `!like`, `not_ilike` y `!ilike` y sus respectivas conversiones y tratamientos.
    - Modificación del reconocimiento y procesamiento de valores para los operadores `not_in` y otras variantes de enumeración.
    - Ajuste del valor de respuesta cuando se usa un operador tipo `like` o sus variantes negadas para asegurar que se busca en el formato correcto.

## Motivación y contexto
Los cambios se introdujeron para mejorar la consistencia y robustez en la implementación de los operadores de comparación en las consultas tanto para MongoDB como para PostgreSQL. La adición de variantes de los operadores como `not_like`, `!like`, `not_ilike` y `!ilike` permite una mayor flexibilidad en las consultas, especialmente en la búsqueda insensible a mayúsculas y minúsculas (case-insensitive search). Estas mejoras ayudan a realizar consultas más precisas y consistentes a través de distintas bases de datos y reducen el riesgo de errores en la lógica de negocios al estandarizar la forma en que se manejan estos operadores.

## Cómo se ha probado
Se debe invocar el metodo Read para servicios de Postgres(stock, sale) como de Mongo(Utilities, Rule, etc)

## Screenshots (si aplica)
\#N/A

## Tipo de cambio
- [X] Bug fix (cambios que solucionan un problema)
- [X] Nueva característica (cambios que añaden funcionalidad)
- [X] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [X] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [X] Mi código sigue las directrices de estilo de este proyecto
- [X] He realizado una auto-revisión de mi propio código
- [X] He comentado mi código, especialmente en áreas difíciles de entender
- [X] He hecho cambios correspondientes en la documentación
- [X] Mis cambios no generan nuevas advertencias
- [X] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [X] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [X] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
\#N/A

[NVOMS-2707]: https://omnipro.atlassian.net/browse/NVOMS-2707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NVOMS-2707]: https://omnipro.atlassian.net/browse/NVOMS-2707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ