### PR TITLE
feat: Disable filtering for a specific field in Descriptor class

### DIFF
--- a/omni/pro/descriptor.py
+++ b/omni/pro/descriptor.py
@@ -221,6 +221,7 @@ class Descriptor(object):
                     "relation": {"name": relation.entity.class_.__name__},
                     "is_exportable": False,
                     "is_importable": False,
+                    "is_filterable": False,
                 }
                 description["fields"].append(relation_info)
 


### PR DESCRIPTION
# [NVOMS-2682](https://omnipro.atlassian.net/browse/NVOMS-2682) - Error al actual Move

## ref [NVOMS-2682](https://omnipro.atlassian.net/browse/NVOMS-2682)

## Descripción
En el archivo `omni/pro/descriptor.py`, dentro de la clase `Descriptor`, se ha agregado un nuevo atributo `is_filterable` al objeto `relation_info`. Este atributo se inicializa con el valor `False`. El bloque de código es parte de la lógica que construye la descripción de los campos de una relación, agregándolos a la lista `description["fields"]`.

## Cambios
1. **Archivo Modificado**: `omni/pro/descriptor.py`
2. **Ubicación del Cambio**: Dentro de la clase `Descriptor`, específicamente en el método que construye la descripción de los campos de una relación.
3. **Línea Añadida**: La línea que agrega el atributo `is_filterable`:
   ```python
   "is_filterable": False,
   ```

## Motivación y contexto
Este cambio corrige el bug para los registros de los modelos en el microservicio de utilidades.

## Cómo se ha probado
Se debe desplegar los microservicios con la versión actualizada incluyendo este cambio.

## Screenshots (si aplica)
\#N/A

## Tipo de cambio
- [X] Bug fix (cambios que solucionan un problema)
- [X] Nueva característica (cambios que añaden funcionalidad)
- [X] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [X] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [X] Mi código sigue las directrices de estilo de este proyecto
- [X] He realizado una auto-revisión de mi propio código
- [X] He comentado mi código, especialmente en áreas difíciles de entender
- [X] He hecho cambios correspondientes en la documentación
- [X] Mis cambios no generan nuevas advertencias
- [X] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [X] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [X] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
\#N/A

[NVOMS-2682]: https://omnipro.atlassian.net/browse/NVOMS-2682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NVOMS-2682]: https://omnipro.atlassian.net/browse/NVOMS-2682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ