### PR TITLE
NVOMS-2857, Configurar la conexión con Redis utilizando el REDIS MANAGER

### DIFF
--- a/omni/pro/celery_manager.py
+++ b/omni/pro/celery_manager.py
@@ -1,0 +1,27 @@
+from celery import Celery
+from omni.pro.redis import RedisManager
+from omni_pro_base.config import Config
+
+
+class RedisCeleryQueueManager(object):
+    def __init__(self, tenant: str):
+        self.tenant = tenant
+        self.redis_manager = RedisManager(
+            host=Config.REDIS_HOST, port=Config.REDIS_PORT, db=Config.REDIS_DB, redis_ssl=Config.REDIS_SSL
+        )
+        self.celery_app = self._setup_celery()
+
+    def _setup_celery(self):
+        conf = self.redis_manager.get_resource_config(service_id=Config.SAAS_REDIS_CELERY, tenant_code=self.tenant)
+        if not conf:
+            raise Exception("Redis Celery configuration not found")
+
+        app = Celery(
+            "tasks",
+            broker=f"redis://{conf['host']}:{conf['port']}/{conf['db']}",
+            backend=f"redis://{conf['host']}:{conf['port']}/{conf['db']}",
+        )
+        return app
+
+    def send_task(self):
+        pass

--- a/omni/pro/celery_manager.py
+++ b/omni/pro/celery_manager.py
@@ -22,6 +22,3 @@ class RedisCeleryQueueManager(object):
             backend=f"redis://{conf['host']}:{conf['port']}/{conf['db']}",
         )
         return app
-
-    def send_task(self):
-        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ newrelic==9.10.0
 sqlalchemy-utils==0.41.1
 alembic==1.11.2
 blinker==1.7.0
+celery==5.4.0
 
 --extra-index-url https://pypi.omni.pro/root/omni-pro/+simple
 omni-pro-base

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ INSTALL_REQUIRES = [
     "newrelic==9.10.0",
     "alembic==1.11.2",
     "blinker==1.7.0",
+    "celery==5.4.0",
 ]
 # with open(HERE / "requirements.txt") as f:
 #     INSTALL_REQUIRES = f.read().splitlines()


### PR DESCRIPTION
# NVOMS-2857, Configurar la conexión con Redis utilizando el REDIS MANAGER
## ref https://omnipro.atlassian.net/browse/NVOMS-2857 

## Descripción
Este PR configura Redis Celery para manejar el borker de celery teniendo en cuenta el tenant del context.

## Cambios
- Creación de la clase `RedisCeleryQueueManager` que permite inicializar y configurar Celery con Redis para un tenant específico.
- Se añade un método `_setup_celery` que obtiene la configuración de Redis para Celery y la aplica al crear la instancia de Celery.
- Configuración de los parámetros `broker` y `backend` de Celery basados en la configuración obtenida desde Redis.

## Motivación y contexto
Esta mejora permite que la aplicación pueda manejar tareas de Celery de forma aislada por cada tenant, utilizando configuraciones específicas para Redis.

## Cómo se ha probado
- Se verificó la correcta inicialización de la clase `RedisCeleryQueueManager` para diferentes tenants, asegurando que se obtengan las configuraciones específicas de Redis sin errores.
- Se comprobó que la configuración de Celery (broker y backend) se establece adecuadamente en función de la configuración obtenida para cada tenant.
- Se realizaron pruebas para validar que la instancia de Celery se crea correctamente y que no genera excepciones durante la configuración inicial.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [ ] He comentado mi código, especialmente en áreas difíciles de entender
- [ ] He hecho cambios correspondientes en la documentación
- [ ] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A