### PR TITLE
NVOMS-2963 - Crear health-check para los MICRO

### DIFF
--- a/omni/pro/health_check.py
+++ b/omni/pro/health_check.py
@@ -1,0 +1,58 @@
+from time import time
+
+from omni.pro.config import Config
+from omni_pro_grpc.v1.util import health_check_pb2
+from pymongo import MongoClient
+from sqlalchemy import text
+
+
+class HealthCheck:
+
+    def _check_service(self, connect_fn, success_message, failure_message):
+        start_time = time()
+        try:
+            connect = connect_fn
+            end_time = time()
+            time_ms = round((end_time - start_time) * 1000, 2)
+
+            if connect is not None:
+                return (
+                    health_check_pb2.ServiceStatus(status="SUCCESS", detail=success_message, time_ms=time_ms),
+                    time_ms,
+                )
+
+            return health_check_pb2.ServiceStatus(status="FAILURE", detail=failure_message, time_ms=time_ms), time_ms
+        except Exception:
+            end_time = time()
+            time_ms = (end_time - start_time) * 1000
+            return health_check_pb2.ServiceStatus(status="FAILURE", detail=failure_message, time_ms=time_ms), time_ms
+
+    def _get_mongo_client(self, db_manager):
+        mongo_uri = f"mongodb://{db_manager.username}:{db_manager.password}@{db_manager.host}:{db_manager.port}/{db_manager.db}?authSource=admin"
+        return MongoClient(mongo_uri)
+
+    def _execute_check_query(self, engine):
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+
+    def check_mongo(self, db_manager):
+        try:
+            mongo_client = self._get_mongo_client(db_manager)
+            return self._check_service(
+                mongo_client.server_info(), "MongoDB connection established", "MongoDB connection failed"
+            )
+        except Exception:
+            return health_check_pb2.ServiceStatus(status="FAILURE", detail="MongoDB connection failed", time_ms=0), 0
+
+    def check_postgres(self, engine):
+        return self._check_service(
+            lambda: self._execute_check_query(engine),
+            "Postgres connection established",
+            "Postgres connection failed",
+        )
+
+    def check_redis(self, redis_client):
+        try:
+            return self._check_service(redis_client.ping(), "Redis connection established", "Redis connection failed")
+        except Exception:
+            return health_check_pb2.ServiceStatus(status="FAILURE", detail="Redis connection failed", time_ms=0), 0


### PR DESCRIPTION
# NVOMS-2963 - Crear health-check para los MICRO

## ref https://omnipro.atlassian.net/browse/NVOMS-2963

## Descripción
Este PR introduce la clase HealthCheck a la librería omni.pro, permitiendo realizar verificaciones de salud para MongoDB, Postgres y Redis.

## Cambios
- Se creó la clase HealthCheck en la librería omni.pro.
- La clase permite realizar checks de conexión para los servicios de MongoDB, Postgres y Redis.
- El método privado _check_service maneja las conexiones y tiempos de respuesta de los servicios, devolviendo un estado de éxito o fallo.
- Métodos adicionales implementados: - check_mongo: Verifica la conexión a MongoDB utilizando las credenciales y configuraciones del db_manager. - check_postgres: Verifica la conexión a Postgres mediante una consulta SQL simple. - check_redis: Verifica la conexión a Redis utilizando el comando ping.

## Motivación y contexto
- Estos cambios son necesarios para centralizar las verificaciones de salud en la librería omni.pro, facilitando su reutilización en los microservicios que dependen de MongoDB, Postgres y Redis.

## Cómo se ha probado
- Se realizaron pruebas compilando la nueva version de la libreria omni.pro, para probarlo del lado de los micros.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A