### PR TITLE
NVOMS-2973 - Agregar unit tests para las librerías

### DIFF
--- a/omni/pro/models/base.py
+++ b/omni/pro/models/base.py
@@ -16,10 +16,10 @@ from mongoengine import (
 )
 from omni.pro.airflow.actions import ActionToAirflow
 from omni.pro.config import Config
+from omni.pro.database.postgres import CustomSession
+from omni.pro.database.sqlalchemy import mapped_column
 from omni.pro.logger import configure_logger
 from omni.pro.util import measure_time
-from omni.pro.database.sqlalchemy import mapped_column
-from omni.pro.database.postgres import CustomSession
 from omni_pro_grpc.common.base_pb2 import Context as ContextProto
 from omni_pro_grpc.common.base_pb2 import Object as ObjectProto
 from omni_pro_grpc.common.base_pb2 import ObjectAudit as AuditProto
@@ -252,6 +252,15 @@ class BaseAuditEmbeddedDocument(BaseEmbeddedDocument):
         "abstract": True,
         "strict": False,
     }
+
+    def update_audit_fields(self):
+        """Actualiza los campos de auditoría."""
+        if not self.context:
+            self.context = Context()
+        if not self.audit:
+            self.audit = Audit(created_by=self.context.user)
+        self.audit.updated_by = self.context.user
+        self.audit.updated_at = datetime.utcnow()
 
     # TODO: Add a method to update the audit fields
     def save(self, *args, **kwargs):

--- a/tests/test_airflow_actions.py
+++ b/tests/test_airflow_actions.py
@@ -1,0 +1,101 @@
+# import unittest
+# from unittest.mock import MagicMock, patch
+
+# from omni.pro.airflow.actions import ActionToAirflow  # Reemplaza con el nombre de tu módulo y clase
+
+
+# class TestSendToAirflow(unittest.TestCase):
+
+#     @patch("omni_pro_redis.redis.RedisManager.get_json")
+#     @patch("omni_pro_redis.redis.RedisManager.get_load_balancer_name")
+#     @patch("omni.pro.airflow.airflow_client_base.AirflowClientBase")  # Mock del cliente Airflow
+#     @patch("omni_pro_grpc.grpc_function.WebhookRPCFucntion")  # Mock de WebhookRPCFucntion
+#     @patch("omni_pro_grpc.grpc_function.EventRPCFucntion")  # Mock de EventRPCFucntion
+#     @patch("omni_pro_grpc.util.MessageToDict")  # Mock de MessageToDict
+#     @patch("omni_pro_base.util.eval_condition")  # Mock de eval_condition
+#     @patch("sqlalchemy.inspection.inspect")  # Mock de inspect
+#     def test_send_to_airflow(
+#         self,
+#         mock_inspect,
+#         mock_eval_condition,
+#         mock_message_to_dict,
+#         mock_event_rpc,
+#         mock_webhook_rpc,
+#         mock_airflow_client,
+#         mock_get_load_balancer_name,
+#         mock_get_json,
+#     ):
+#         mock_get_load_balancer_name.return_value = "mocked_load_balancer_name"
+#         mock_get_json.return_value = {"tenant_code": "mocked_tenant_code"}  # Simulamos que existe tenant_code en Redis
+
+#         # Mocks de los parámetros de entrada
+#         cls_name = MagicMock()
+#         cls_name._collection.name = "mock_model"  # Simulando un Document
+#         instance = MagicMock()
+#         instance.generate_dict.return_value = {"field": "value"}
+#         instance.__is_replic_table__ = True
+#         action = "update"
+#         context = {"tenant": "tenant_code", "user": "user_name"}
+
+#         # Mock de la respuesta del RPC para EventRPCFucntion
+#         mock_event_rpc_instance = mock_event_rpc.return_value
+#         mock_event_rpc_instance.read_event.return_value = (
+#             MagicMock(events=[{"operation": "update", "id": 1}]),
+#             True,
+#             None,
+#         )
+
+#         # Mock de la respuesta del RPC para WebhookRPCFucntion
+#         mock_webhook_rpc_instance = mock_webhook_rpc.return_value
+#         mock_webhook_rpc_instance.read_webhook.return_value = (
+#             MagicMock(
+#                 webhooks=[
+#                     {
+#                         "dag_id": "dag_test",
+#                         "trigger_fields": ["mock_model-field"],
+#                         "type_webhook": "external",
+#                         "python_code": "",
+#                     }
+#                 ]
+#             ),
+#             True,
+#             None,
+#         )
+
+#         # Mock de inspect y eval_condition
+#         mock_inspect.return_value.attrs = [
+#             MagicMock(key="field", history=MagicMock(has_changes=MagicMock(return_value=True)))
+#         ]
+#         mock_eval_condition.return_value = True  # Siempre pasar la condición
+
+#         print(f"cls_name: {cls_name}, instance: {instance}, action: {action}, context: {context}")
+#         # Ejecuta el método que se está probando
+#         ActionToAirflow.send_to_airflow(cls_name, instance, action, context)
+
+#         self.assertTrue(mock_airflow_client.called, "AirflowClientBase no fue llamado")
+
+#         # Verificar que se llamó a AirflowClientBase con los parámetros correctos
+#         mock_airflow_client.assert_called_once_with(context["tenant"])
+#         mock_airflow_client_instance = mock_airflow_client.return_value
+#         mock_airflow_client_instance.run_dag.assert_called_once_with(
+#             dag_id="dag_test",
+#             params={
+#                 "instance": {"field": "value"},  # Lo que genera generate_dict
+#                 "action_code": "mock_model_update",
+#                 "context": context,
+#                 "webhook": {
+#                     "dag_id": "dag_test",
+#                     "trigger_fields": ["mock_model-field"],
+#                     "type_webhook": "external",
+#                     "python_code": "",
+#                 },
+#             },
+#         )
+
+#         # Verificar que se llamaron las funciones auxiliares como eval_condition
+#         mock_eval_condition.assert_called_once_with({"field": "value"}, "")
+#         mock_inspect.assert_called_once_with(instance)
+
+
+# if __name__ == "__main__":
+#     unittest.main()

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from omni.pro.aws.client import AWSClient
+
+
+class TestAWSClient(unittest.TestCase):
+
+    @patch("boto3.client")
+    def test_aws_client_initialization(self, mock_boto_client):
+        mock_service_model = MagicMock()
+        mock_service_model.service_name = "s3"
+
+        mock_boto_client.return_value._service_model = mock_service_model
+
+        service_name = "s3"
+        region_name = "us-east-1"
+        aws_access_key_id = "AKIAIOS"
+        aws_secret_access_key = "wJal"
+
+        aws_client = AWSClient(service_name, region_name, aws_access_key_id, aws_secret_access_key)
+
+        mock_boto_client.assert_called_once_with(
+            service_name=service_name,
+            region_name=region_name,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+        )
+
+        self.assertEqual(aws_client._client._service_model.service_name, service_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aws_cloudmap.py
+++ b/tests/test_aws_cloudmap.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch
+
+from omni.pro.aws.cloudmap import AWSCloudMap
+
+
+class TestAWSCloudMap(unittest.TestCase):
+
+    @patch("boto3.client")
+    def test_discover_instances(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.discover_instances.return_value = {
+            "Instances": [{"Attributes": {"host": "127.0.0.1", "port": "6379", "db": "0"}}]
+        }
+
+        aws_cloud_map = AWSCloudMap(
+            region_name="us-east-1",
+            namespace_name="test-namespace",
+            service_name="test-service",
+            aws_access_key_id="test-key-id",
+            aws_secret_access_key="test-secret-key",
+        )
+
+        instances = aws_cloud_map.discover_instances()
+
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0]["Attributes"]["host"], "127.0.0.1")
+        self.assertEqual(instances[0]["Attributes"]["port"], "6379")
+
+        mock_boto_client_instance.discover_instances.assert_called_once_with(
+            NamespaceName="test-namespace", ServiceName="test-service"
+        )
+
+    @patch("boto3.client")
+    def test_get_redis_config(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.discover_instances.return_value = {
+            "Instances": [{"Attributes": {"host": "127.0.0.1", "port": "6379", "db": "0"}}]
+        }
+
+        aws_cloud_map = AWSCloudMap(
+            region_name="us-east-1",
+            namespace_name="test-namespace",
+            service_name="test-service",
+            aws_access_key_id="test-key-id",
+            aws_secret_access_key="test-secret-key",
+        )
+
+        redis_config = aws_cloud_map.get_redis_config()
+
+        self.assertEqual(redis_config["host"], "127.0.0.1")
+        self.assertEqual(redis_config["port"], 6379)
+        self.assertEqual(redis_config["db"], 0)
+
+        mock_boto_client_instance.discover_instances.assert_called_once_with(
+            NamespaceName="test-namespace", ServiceName="test-service"
+        )
+
+    @patch("boto3.client")
+    def test_discover_instances_no_instances(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.discover_instances.return_value = {"Instances": []}
+
+        aws_cloud_map = AWSCloudMap(
+            region_name="us-east-1",
+            namespace_name="test-namespace",
+            service_name="test-service",
+            aws_access_key_id="test-key-id",
+            aws_secret_access_key="test-secret-key",
+        )
+
+        with self.assertRaises(Exception) as context:
+            aws_cloud_map.discover_instances()
+
+        self.assertEqual(str(context.exception), "No instances found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aws_cognito.py
+++ b/tests/test_aws_cognito.py
@@ -1,0 +1,148 @@
+import unittest
+from http import HTTPStatus
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+from omni.pro.aws.cognito import AWSCognitoClient
+
+
+class TestAWSCognitoClient(unittest.TestCase):
+
+    @patch("boto3.client")
+    def test_get_user(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.admin_get_user.return_value = {
+            "Username": "test_user",
+            "UserAttributes": [
+                {"Name": "email", "Value": "user@example.com"},
+            ],
+        }
+
+        cognito_client = AWSCognitoClient(
+            region_name="us-east-1",
+            aws_access_key_id="test-key-id",
+            aws_secret_access_key="test-secret-key",
+            user_pool_id="us-east-1_123456789",
+            client_id="1234567890123456789012",
+        )
+
+        user_info = cognito_client.get_user(username="test_user")
+
+        mock_boto_client_instance.admin_get_user.assert_called_once_with(
+            UserPoolId="us-east-1_123456789", Username="test_user"
+        )
+
+        self.assertEqual(user_info["Username"], "test_user")
+
+    @patch("omni.pro.aws.cognito.generate_strong_password", return_value="temporary_password")
+    @patch("boto3.client")
+    def test_create_user(self, mock_boto_client, mock_generate_password):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.admin_create_user.return_value = {"User": "created"}
+
+        cognito_client = AWSCognitoClient(
+            region_name="us-east-1",
+            aws_access_key_id="test-key-id",
+            aws_secret_access_key="test-secret-key",
+            user_pool_id="us-east-1_123456789",
+            client_id="1234567890123456789012",
+        )
+
+        response = cognito_client.create_user(
+            username="test_user",
+            password="Password123!",
+            name="John Doe",
+            email="john.doe@example.com",
+            tenant="tenant1",
+            language_code="en-US",
+            timezone_code="UTC",
+        )
+
+        mock_boto_client_instance.admin_create_user.assert_called_once_with(
+            UserPoolId="us-east-1_123456789",
+            Username="test_user",
+            TemporaryPassword="temporary_password",
+            UserAttributes=[
+                {"Name": "name", "Value": "John Doe"},
+                {"Name": "email", "Value": "john.doe@example.com"},
+                {"Name": "custom:tenant", "Value": "tenant1"},
+                {"Name": "locale", "Value": "en-US"},
+                {"Name": "zoneinfo", "Value": "UTC"},
+            ],
+        )
+
+        self.assertEqual(response["User"], "created")
+
+    @patch("boto3.client")
+    def test_delete_user(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.admin_delete_user.return_value = {"Response": "deleted"}
+
+        cognito_client = AWSCognitoClient(
+            region_name="us-east-1",
+            aws_access_key_id="test-key-id",
+            aws_secret_access_key="test-secret-key",
+            user_pool_id="us-east-1_123456789",
+            client_id="1234567890123456789012",
+        )
+
+        response = cognito_client.delete_user(username="test_user")
+
+        mock_boto_client_instance.admin_delete_user.assert_called_once_with(
+            UserPoolId="us-east-1_123456789", Username="test_user"
+        )
+
+        self.assertEqual(response["Response"], "deleted")
+
+    @patch("boto3.client")
+    def test_init_auth_success(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.initiate_auth.return_value = {
+            "AuthenticationResult": {"IdToken": "id_token", "RefreshToken": "refresh_token", "ExpiresIn": 3600}
+        }
+
+        cognito_client = AWSCognitoClient(
+            region_name="us-east-1",
+            aws_access_key_id="test-key-id",
+            aws_secret_access_key="test-secret-key",
+            user_pool_id="us-east-1_123456789",
+            client_id="1234567890123456789012",
+        )
+
+        status_code, auth_result, message = cognito_client.init_auth(username="test_user", password="Password123!")
+
+        mock_boto_client_instance.initiate_auth.assert_called_once_with(
+            ClientId="1234567890123456789012",
+            AuthFlow="USER_PASSWORD_AUTH",
+            AuthParameters={"USERNAME": "test_user", "PASSWORD": "Password123!"},
+        )
+
+        self.assertEqual(status_code, HTTPStatus.OK)
+        self.assertEqual(auth_result["token"], "id_token")
+        self.assertEqual(auth_result["refresh_token"], "refresh_token")
+        self.assertEqual(message, "Success")
+
+    @patch("boto3.client")
+    def test_init_auth_failure(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.initiate_auth.side_effect = ClientError(
+            error_response={"Error": {"Code": "NotAuthorizedException", "Message": "User is not authorized"}},
+            operation_name="initiate_auth",
+        )
+
+        cognito_client = AWSCognitoClient(
+            region_name="us-east-1",
+            aws_access_key_id="test-key-id",
+            aws_secret_access_key="test-secret-key",
+            user_pool_id="us-east-1_123456789",
+            client_id="1234567890123456789012",
+        )
+
+        status_code, auth_result, message = cognito_client.init_auth(username="test_user", password="Password123!")
+
+        self.assertEqual(status_code, HTTPStatus.UNAUTHORIZED)
+        self.assertEqual(message, "Invalid auth data")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aws_s3.py
+++ b/tests/test_aws_s3.py
@@ -1,0 +1,119 @@
+import unittest
+from unittest.mock import patch
+
+from omni.pro.aws.s3 import AWSS3Client
+
+
+class TestAWSS3Client(unittest.TestCase):
+
+    @patch("boto3.client")
+    def test_download_file(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.download_file.return_value = None
+
+        s3_client = AWSS3Client(
+            bucket_name="my-bucket",
+            region_name="us-east-1",
+            aws_access_key_id="fake-access-key",
+            aws_secret_access_key="fake-secret-key",
+            allowed_files=[".txt", ".png"],
+        )
+
+        result = s3_client.download_file("my-object.txt", "/tmp/my-object.txt")
+
+        mock_boto_client_instance.download_file.assert_called_once_with(
+            "my-bucket", "my-object.txt", "/tmp/my-object.txt"
+        )
+        self.assertIsNone(result)
+
+    @patch("boto3.client")
+    def test_upload_file(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.upload_file.return_value = None
+
+        s3_client = AWSS3Client(
+            bucket_name="my-bucket",
+            region_name="us-east-1",
+            aws_access_key_id="fake-access-key",
+            aws_secret_access_key="fake-secret-key",
+            allowed_files=[".txt", ".png"],
+        )
+
+        result = s3_client.upload_file("my-object.txt", "/tmp/my-object.txt")
+
+        mock_boto_client_instance.upload_file.assert_called_once_with(
+            "/tmp/my-object.txt", "my-bucket", "my-object.txt"
+        )
+        self.assertEqual(result, "my-object.txt")
+
+    @patch("boto3.client")
+    def test_generate_presigned_post(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.generate_presigned_post.return_value = {"url": "http://presigned-url"}
+
+        s3_client = AWSS3Client(
+            bucket_name="my-bucket",
+            region_name="us-east-1",
+            aws_access_key_id="fake-access-key",
+            aws_secret_access_key="fake-secret-key",
+            allowed_files=[".txt", ".png"],
+        )
+
+        presigned_post = s3_client.generate_presigned_post("my-object.txt")
+
+        mock_boto_client_instance.generate_presigned_post.assert_called_once_with(
+            "my-bucket", "my-object.txt", ExpiresIn=3600
+        )
+        self.assertEqual(presigned_post["url"], "http://presigned-url")
+
+    @patch("boto3.client")
+    def test_upload_file_to_s3_binary(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.put_object.return_value = None
+
+        s3_client = AWSS3Client(
+            bucket_name="my-bucket",
+            region_name="us-east-1",
+            aws_access_key_id="fake-access-key",
+            aws_secret_access_key="fake-secret-key",
+            allowed_files=[".txt", ".png"],
+        )
+
+        url = s3_client.upload_file_to_s3_binary("my-object.txt", "01101000011001010110110001101100", "text/plain")
+
+        mock_boto_client_instance.put_object.assert_called_once_with(
+            Bucket="my-bucket", Key="my-object.txt", Body=b"\x68\x65\x6c\x6c", ContentType="text/plain"
+        )
+
+        self.assertEqual(url, "https://my-bucket.s3.amazonaws.com/my-object.txt")
+
+    @patch("boto3.client")
+    def test_get_object_metadata(self, mock_boto_client):
+        mock_boto_client_instance = mock_boto_client.return_value
+        mock_boto_client_instance.head_object.return_value = {
+            "ContentLength": 1234,
+            "ContentType": "text/plain",
+            "ETag": '"etag"',
+            "LastModified": "2024-01-01T12:34:56",
+        }
+
+        s3_client = AWSS3Client(
+            bucket_name="my-bucket",
+            region_name="us-east-1",
+            aws_access_key_id="fake-access-key",
+            aws_secret_access_key="fake-secret-key",
+            allowed_files=[".txt", ".png"],
+        )
+
+        metadata = s3_client.get_object_metadata("my-object.txt")
+
+        mock_boto_client_instance.head_object.assert_called_once_with(Bucket="my-bucket", Key="my-object.txt")
+
+        self.assertEqual(metadata["ContentLength"], 1234)
+        self.assertEqual(metadata["ContentType"], "text/plain")
+        self.assertEqual(metadata["ETag"], '"etag"')
+        self.assertEqual(metadata["LastModified"], "2024-01-01T12:34:56")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_celery_celery_redis.py
+++ b/tests/test_celery_celery_redis.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import patch
+
+from omni.pro.celery.celery_redis import CeleryRedis
+
+
+class TestCeleryRedis(unittest.TestCase):
+
+    @patch("omni.pro.celery.celery_redis.Celery", autospec=True)
+    @patch("omni.pro.redis.RedisManager.get_resource_config")
+    @patch("omni_pro_base.config.Config")
+    def test_get_celery_app_by_tenant(self, mock_config, mock_get_resource_config, mock_celery):
+        mock_config.REDIS_HOST = "localhost"
+        mock_config.REDIS_PORT = 6379
+        mock_config.REDIS_DB = 0
+        mock_config.REDIS_SSL = False
+        mock_config.SAAS_REDIS_CELERY = "saas-redis-celery"
+
+        mock_get_resource_config.return_value = {"host": "localhost", "port": 6379, "db": 1}
+
+        mock_celery_instance = mock_celery.return_value
+
+        tenant = "test_tenant"
+        app = CeleryRedis.get_celery_app_by_tenant(tenant)
+
+        mock_get_resource_config.assert_called_once_with(service_id="saas-redis-celery", tenant_code=tenant)
+
+        mock_celery.assert_called_once_with(
+            "tasks", broker="redis://localhost:6379/1", backend="redis://localhost:6379/1"
+        )
+
+        self.assertEqual(app, mock_celery_instance)
+
+    @patch("omni.pro.redis.RedisManager.get_resource_config")
+    def test_get_celery_app_by_tenant_no_config(self, mock_get_resource_config):
+        mock_get_resource_config.return_value = None
+
+        tenant = "test_tenant"
+        with self.assertRaises(Exception) as context:
+            CeleryRedis.get_celery_app_by_tenant(tenant)
+
+        self.assertEqual(str(context.exception), "Redis Celery configuration not found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check_migration.py
+++ b/tests/test_check_migration.py
@@ -1,0 +1,72 @@
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from omni.pro.check_migration import AlembicMigrateCheck
+
+
+class TestAlembicMigrateCheck(unittest.TestCase):
+
+    def setUp(self):
+        self.path = Path("/fake/path")
+        self.handler = AlembicMigrateCheck(self.path)
+        self.handler.redis_manager = MagicMock()
+        self.handler.engine = MagicMock()
+
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.ensure_database_exists")
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.check")
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.get_current_version")
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.is_database_up_to_date", return_value=False)
+    @patch(
+        "omni.pro.check_migration.AlembicMigrateCheck.apply_revision",
+        return_value=(True, MagicMock(revision="rev_123")),
+    )
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.no_changes_detected", return_value=False)
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.upgrade_head")
+    def test_apply_success(
+        self,
+        mock_upgrade_head,
+        mock_no_changes,
+        mock_apply_revision,
+        mock_is_db_up_to_date,
+        mock_get_current_version,
+        mock_check,
+        mock_ensure_db,
+    ):
+        self.handler.apply()
+        mock_check.assert_called_once()
+        mock_get_current_version.assert_called()
+        mock_upgrade_head.assert_called_with("rev_123")
+        mock_apply_revision.assert_called_once()
+
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.get_current_version", return_value="version_1")
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.is_database_up_to_date", return_value=True)
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.apply_revision")
+    def test_apply_no_upgrade_needed(self, mock_apply_revision, mock_is_db_up_to_date, mock_get_current_version):
+        self.handler.apply()
+        mock_apply_revision.assert_called_once()
+        mock_is_db_up_to_date.assert_called_once()
+
+    @patch("omni.pro.check_migration.AlembicMigrateCheck.get_postgres_config")
+    def test_get_postgres_config(self, mock_get_postgres_config):
+        self.handler.get_postgres_config("service_id", "tenant_code")
+        mock_get_postgres_config.assert_called_once_with("service_id", "tenant_code")
+
+    @patch("omni.pro.check_migration.command.upgrade")
+    @patch("omni.pro.check_migration.logger")
+    def test_upgrade_head(self, mock_logger, mock_upgrade):
+        self.handler.upgrade_head()
+        mock_upgrade.assert_called_once_with(self.handler.alembic_config, "head")
+
+    @patch("omni.pro.check_migration.inspect_sqlalchemy")
+    def test_check_alembic_version_table(self, mock_inspect):
+        mock_inspector = MagicMock()
+        mock_inspect.return_value = mock_inspector
+        mock_inspector.has_table.return_value = False
+        result = self.handler.check()
+        self.assertFalse(result)
+        mock_inspector.has_table.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_database_connection.py
+++ b/tests/test_database_connection.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest.mock import patch
+
+import mongoengine as mongo
+from omni.pro.database_connection import RedisManager, ms_register_connection, register_logger_connection
+from omni_pro_base.config import Config
+
+
+class TestRegisterLoggerConnection(unittest.TestCase):
+
+    @patch("omni.pro.database_connection.mongo.register_connection")
+    @patch.object(RedisManager, "get_mongodb_config")
+    def test_register_logger_connection(self, mock_get_mongodb_config, mock_register_connection):
+        mock_get_mongodb_config.return_value = {
+            "name": "test_db",
+            "host": "localhost",
+            "port": "27017",
+            "user": "test_user",
+            "password": "test_pass",
+            "complement": {},
+        }
+
+        Config.SERVICE_ID = "saas-loggers-oms"
+
+        manager = RedisManager(host="localhost", port="6379", db="0", redis_ssl=False)
+
+        register_logger_connection("test_tenant", manager)
+
+        mock_get_mongodb_config.assert_called_once_with(Config.SERVICE_ID, "test_tenant")
+
+        mock_register_connection.assert_called_once_with(
+            alias="test_tenant_test_db",
+            name="test_db",
+            host="localhost",
+            port=27017,
+            username="test_user",
+            password="test_pass",
+            **{}
+        )
+
+
+class TestMsRegisterConnection(unittest.TestCase):
+
+    @patch("omni.pro.database_connection.mongo.register_connection")
+    @patch("omni.pro.database_connection.register_logger_connection")
+    @patch.object(RedisManager, "get_mongodb_config")
+    @patch.object(RedisManager, "get_tenant_codes")
+    def test_ms_register_connection(
+        self, mock_get_tenant_codes, mock_get_mongodb_config, mock_register_logger_connection, mock_register_connection
+    ):
+        mock_get_tenant_codes.return_value = ["tenant1", "tenant2"]
+
+        mock_get_mongodb_config.return_value = {
+            "name": "test_db",
+            "host": "localhost",
+            "port": "27017",
+            "user": "test_user",
+            "password": "test_pass",
+            "complement": {},
+        }
+
+        ms_register_connection(logger_oms=True)
+
+        mock_get_tenant_codes.assert_called_once()
+
+        self.assertEqual(mock_get_mongodb_config.call_count, 2)
+
+        self.assertEqual(mock_register_connection.call_count, 3)
+
+        self.assertEqual(mock_register_logger_connection.call_count, 2)
+
+        mock_register_connection.assert_any_call(
+            alias="tenant1_test_db",
+            name="test_db",
+            host="localhost",
+            port=27017,
+            username="test_user",
+            password="test_pass",
+            **{}
+        )
+
+        mock_register_connection.assert_any_call(
+            alias="tenant2_test_db",
+            name="test_db",
+            host="localhost",
+            port=27017,
+            username="test_user",
+            password="test_pass",
+            **{}
+        )
+
+        mock_register_connection.assert_any_call(
+            alias=mongo.DEFAULT_CONNECTION_NAME,
+            name=mongo.DEFAULT_CONNECTION_NAME,
+            host="localhost",
+            port=27017,
+            username="test_user",
+            password="test_pass",
+            **{}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_database_mongo.py
+++ b/tests/test_database_mongo.py
@@ -1,0 +1,578 @@
+import unittest
+from unittest.mock import ANY, MagicMock, patch
+
+from bson import ObjectId
+from omni.pro.database.mongo import DatabaseManager, DBUtil, MongoConnection, PolishNotationToMongoDB
+from omni.pro.exceptions import AlreadyExistError
+from omni_pro_grpc.common import base_pb2
+
+
+class TestDatabaseManager(unittest.TestCase):
+
+    def setUp(self):
+        self.db_manager = DatabaseManager(
+            host="localhost", port=27017, db="test_db", user="root", password="123456", complement={}
+        )
+
+    def test_create_document(self):
+        mock_document_class = MagicMock()
+
+        document_instance = self.db_manager.create_document(
+            "test_db", mock_document_class, field1="value1", field2="value2"
+        )
+
+        mock_document_class.assert_called_once_with(field1="value1", field2="value2")
+        document_instance.save.assert_called_once()
+
+    def test_get_document(self):
+        mock_document_class = MagicMock()
+
+        mock_document_instance = MagicMock()
+        mock_document_class.objects.return_value.first.return_value = mock_document_instance
+
+        result = self.db_manager.get_document("test_db", "tenant_code", mock_document_class, field="value")
+
+        mock_document_class.objects.assert_called_once_with(field="value", context__tenant="tenant_code")
+        self.assertEqual(result, mock_document_instance)
+
+    def test_update_document(self):
+        mock_document_class = MagicMock()
+
+        mock_document_instance = MagicMock()
+        mock_document_instance.id = "12345"
+        mock_document_class.objects.return_value.first.return_value = mock_document_instance
+
+        result = self.db_manager.update_document("test_db", mock_document_class, id="12345", field="new_value")
+        mock_document_class.objects.assert_called_with(id="12345")
+        mock_document_instance.update.assert_called_once_with(field="new_value")
+        mock_document_instance.reload.assert_called_once()
+        self.assertEqual(result, mock_document_instance)
+
+    def test_delete(self):
+        mock_document_instance = MagicMock()
+
+        deleted_document = self.db_manager.delete(mock_document_instance)
+
+        mock_document_instance.delete.assert_called_once()
+        self.assertEqual(deleted_document, mock_document_instance)
+
+    def test_delete_document(self):
+        mock_document_class = MagicMock()
+
+        mock_document_instance = MagicMock()
+        mock_document_class.objects.return_value.first.return_value = mock_document_instance
+
+        deleted_document = self.db_manager.delete_document("test_db", mock_document_class, id="12345")
+
+        mock_document_class.objects.assert_called_with(id="12345")
+        mock_document_instance.delete.assert_called_once()
+
+        self.assertEqual(deleted_document, mock_document_instance)
+
+    @patch("time.time", side_effect=[0, 1])
+    def test_list_documents(self, mock_time):
+        mock_document_class = MagicMock()
+
+        mock_query_set = MagicMock()
+
+        mock_query_set.count.return_value = 5
+
+        mock_document_class.objects.return_value = mock_query_set
+        mock_query_set.only.return_value = mock_query_set
+        mock_query_set.order_by.return_value = mock_query_set
+        mock_query_set.limit.return_value = mock_query_set
+        mock_query_set.skip.return_value = mock_query_set
+        mock_query_set.__getitem__.return_value = mock_query_set
+
+        documents, total_count = self.db_manager.list_documents(
+            db_name="test_db",
+            tenant="tenant_code",
+            document_class=mock_document_class,
+            fields=["field1", "field2"],
+            paginated={"page": 1, "per_page": 10},
+            sort_by=["-field1"],
+        )
+
+        mock_document_class.objects.assert_called_once_with(context__tenant="tenant_code")
+
+        mock_query_set.only.assert_called_once_with("field1", "field2")
+
+        print(f"documents: {documents}, total_count: {total_count}")
+
+        self.assertEqual(documents, list(mock_query_set))
+        self.assertEqual(total_count, 5)
+
+    @patch("omni.pro.database.mongo.MongoConnection")
+    def test_list_documents(self, mock_mongo_connection):
+        mock_document_class = MagicMock()
+
+        mock_collection = mock_document_class._get_collection.return_value
+        mock_aggregate_result = [
+            {"_id": "1", "name": "document1"},
+            {"_id": "2", "name": "document2"},
+        ]
+        mock_collection.aggregate.return_value = mock_aggregate_result
+
+        filter_conditions = [("name", "=", "document1")]
+        query_set = self.db_manager._list_documents(
+            tenant="tenant_code",
+            filter_conditions=filter_conditions,
+            id=None,
+            document_class=mock_document_class,
+            paginated={"page": 1, "per_page": 10},
+            sort=["+name"],
+        )
+
+        mock_collection.aggregate.assert_called_once()
+        called_pipeline = mock_collection.aggregate.call_args[0][0]
+
+        self.assertIn({"$match": {"name": {"$eq": "document1"}}}, called_pipeline)
+        self.assertIn({"$sort": {"name": 1}}, called_pipeline)
+
+        self.assertEqual(query_set, [mock_document_class._from_son(item) for item in mock_aggregate_result])
+
+    def test_parse_expression_to_pipeline(self):
+        mock_document_class = MagicMock()
+
+        filter_conditions = [("name", "like", "doc")]
+
+        pipeline = self.db_manager.parse_expression_to_pipeline(
+            document_class=mock_document_class,
+            filter_conditions=filter_conditions,
+            id=None,
+            sort=["+name"],
+            paginated={"page": 1, "per_page": 10},
+        )
+
+        expected_match = {"$match": {"name": {"$regex": "doc", "$options": "i"}}}
+        expected_sort = {"$sort": {"name": 1}}
+        expected_skip = {"$skip": 0}
+        expected_limit = {"$limit": 10}
+
+        self.assertIn(expected_match, pipeline)
+        self.assertIn(expected_sort, pipeline)
+        self.assertIn(expected_skip, pipeline)
+        self.assertIn(expected_limit, pipeline)
+
+    def test_delete_documents(self):
+        mock_document_class = MagicMock()
+        mock_delete_result = MagicMock()
+        mock_document_class.objects.return_value.delete.return_value = mock_delete_result
+
+        result = self.db_manager.delete_documents(
+            db_name="test_db", document_class=mock_document_class, some_field="some_value"
+        )
+
+        mock_document_class.objects.assert_called_once_with(some_field="some_value")
+
+        mock_document_class.objects().delete.assert_called_once()
+
+        self.assertEqual(result, mock_delete_result)
+
+    def test_update_embeded_document_single(self):
+        mock_document_class = MagicMock()
+
+        mock_update_result = MagicMock()
+        mock_document_class.objects.return_value.update_one.return_value = mock_update_result
+        mock_document_class.objects.return_value.first.return_value = "updated_document"
+
+        result = self.db_manager.update_embeded_document(
+            db_name="test_db",
+            document_class=mock_document_class,
+            filters={"_id": "123"},
+            update={"$set": {"field": "value"}},
+            many=False,
+        )
+
+        self.assertEqual(mock_document_class.objects.call_count, 2)
+        mock_document_class.objects.assert_any_call(_id="123")
+        mock_document_class.objects().update_one.assert_called_once_with(**{"$set": {"field": "value"}})
+        mock_document_class.objects().first.assert_called_once()
+
+        self.assertEqual(result, "updated_document")
+
+    def test_update_embeded_document_many(self):
+        mock_document_class = MagicMock()
+
+        mock_update_result = MagicMock()
+        mock_document_class.objects.return_value.update.return_value = mock_update_result
+        mock_document_class.objects.return_value.return_value = ["updated_doc1", "updated_doc2"]
+
+        result = self.db_manager.update_embeded_document(
+            db_name="test_db",
+            document_class=mock_document_class,
+            filters={"_id": "123"},
+            update={"$set": {"field": "value"}},
+            many=True,
+        )
+
+        self.assertEqual(mock_document_class.objects.call_count, 2)
+        mock_document_class.objects.assert_any_call(_id="123")
+        mock_document_class.objects().update.assert_called_once_with(**{"$set": {"field": "value"}})
+
+        self.assertEqual(result, mock_document_class.objects())
+
+    @patch("omni.pro.database.mongo.UpdateOne")
+    def test_batch_upsert(self, mock_update_one):
+        mock_document_instance = MagicMock()
+        mock_collection = mock_document_instance._get_collection.return_value
+
+        data = {
+            "context": {"tenant": "tenant_code", "user": "user_name"},
+            "models": [{"external_id": "1", "field": "value1"}, {"external_id": "2", "field": "value2"}],
+        }
+
+        self.db_manager.batch_upsert(mock_document_instance, data)
+
+        mock_update_one.assert_any_call(
+            {"external_id": "1"},
+            {"$set": {"external_id": "1", "field": "value1", "tenant": "tenant_code", "updated_by": "user_name"}},
+            upsert=True,
+        )
+        mock_update_one.assert_any_call(
+            {"external_id": "2"},
+            {"$set": {"external_id": "2", "field": "value2", "tenant": "tenant_code", "updated_by": "user_name"}},
+            upsert=True,
+        )
+
+        mock_collection.bulk_write.assert_called_once()
+
+    @patch.object(DatabaseManager, "remove_document_relations")
+    @patch.object(DatabaseManager, "add_document_relations")
+    def test_add_or_remove_document_relations(self, mock_add_relations, mock_remove_relations):
+        existent_relations = [MagicMock(code="relation1"), MagicMock(code="relation2")]
+        new_relations = [{"code": "relation2"}, {"code": "relation3"}]
+
+        result = self.db_manager.add_or_remove_document_relations(
+            context={},
+            document=MagicMock(),
+            exsitent_relations_list=existent_relations,
+            new_relations_list=new_relations,
+            attribute_search="code",
+            request_context={},
+            element_name="Element",
+            element_relation_name="Relation",
+            multiple_params=False,
+        )
+
+        mock_remove_relations.assert_called_once_with(
+            ANY,
+            ANY,
+            ["relation1"],
+            existent_relations,
+            "code",
+            {},
+            "Element",
+            "Relation",
+            False,
+        )
+
+        mock_add_relations.assert_called_once_with(
+            ANY,
+            ANY,
+            ["relation3"],
+            ANY,
+            "code",
+            {},
+            "Element",
+            "Relation",
+            False,
+        )
+
+    @patch.object(DatabaseManager, "get_register")
+    def test_remove_document_relations(self, mock_get_register):
+        existent_relations = [MagicMock(code="relation1")]
+
+        mock_get_register.return_value = existent_relations[0]
+
+        result = self.db_manager.remove_document_relations(
+            context={},
+            document=MagicMock(),
+            list_elements=["relation1"],
+            list_registers=existent_relations,
+            attribute_search="code",
+            request_context={},
+            element_name="Element",
+            element_relation_name="Relation",
+            multiple_params=False,
+        )
+
+        self.assertEqual(result, [])
+
+        mock_get_register.assert_called_once_with("code", {}, ANY, "relation1", {}, False)
+
+    @patch.object(DatabaseManager, "get_register")
+    def test_add_document_relations(self, mock_get_register):
+        mock_register1 = MagicMock()
+        mock_register2 = MagicMock()
+
+        def side_effect_func(attribute_search, context, document, element, request_context, multiple_params):
+            if element == "relation1":
+                return mock_register1
+            elif element == "relation2":
+                return mock_register2
+            return None
+
+        mock_get_register.side_effect = side_effect_func
+
+        existent_relations = [mock_register1]
+
+        new_relations = ["relation2"]
+
+        result = self.db_manager.add_document_relations(
+            context={},
+            document=MagicMock(),
+            list_elements=new_relations,
+            list_registers=existent_relations,
+            attribute_search="id",
+            request_context={},
+            element_name="Element",
+            element_relation_name="Relation",
+            multiple_params=False,
+        )
+
+        self.assertIn(mock_register2, result)
+        mock_get_register.assert_any_call("id", {}, ANY, "relation2", {}, False)
+
+    @patch.object(DatabaseManager, "get_register")
+    def test_add_document_relations_already_exists(self, mock_get_register):
+        mock_register = MagicMock()
+        mock_get_register.return_value = mock_register
+
+        existent_relations = [mock_register]
+
+        with self.assertRaises(AlreadyExistError):
+            self.db_manager.add_document_relations(
+                context={},
+                document=MagicMock(),
+                list_elements=["relation1"],
+                list_registers=existent_relations,
+                attribute_search="id",
+                request_context={},
+                element_name="Element",
+                element_relation_name="Relation",
+                multiple_params=False,
+            )
+
+    @patch.object(DatabaseManager, "get_register")
+    def test_get_register(self, mock_get_register):
+        mock_document = MagicMock()
+
+        result = self.db_manager.get_register(
+            attribute_search="id",
+            context={},
+            document=mock_document,
+            element="relation1",
+            request_context={"tenant": "tenant1"},
+            multiple_params=False,
+        )
+
+        mock_get_register.assert_called_once_with(
+            attribute_search="id",
+            context={},
+            document=mock_document,
+            element="relation1",
+            request_context={"tenant": "tenant1"},
+            multiple_params=False,
+        )
+
+
+class TestMongoConnection(unittest.TestCase):
+
+    @patch("mongoengine.connect")
+    def test_connect(self, mock_connect):
+        host = "localhost"
+        port = 27017
+        db = "test_db"
+        username = "user"
+        password = "password"
+        complement = {"authSource": "admin"}
+
+        mongo_conn = MongoConnection(host, port, db, username, password, complement)
+
+        connection = mongo_conn.connect()
+
+        mock_connect.assert_called_once_with(
+            db=db, username=username, password=password, host="mongodb://localhost:27017/?authSource=admin"
+        )
+
+        self.assertEqual(connection, mock_connect.return_value)
+
+    @patch("mongoengine.disconnect")
+    def test_close(self, mock_disconnect):
+        host = "localhost"
+        port = 27017
+        db = "test_db"
+        username = "user"
+        password = "password"
+        complement = {"authSource": "admin"}
+
+        mongo_conn = MongoConnection(host, port, db, username, password, complement)
+
+        mongo_conn.close()
+
+        mock_disconnect.assert_called_once()
+
+    @patch("mongoengine.connect")
+    @patch("mongoengine.disconnect")
+    def test_context_manager(self, mock_disconnect, mock_connect):
+        host = "localhost"
+        port = 27017
+        db = "test_db"
+        username = "user"
+        password = "password"
+        complement = {"authSource": "admin"}
+
+        with MongoConnection(host, port, db, username, password, complement) as mongo_conn:
+            mock_connect.assert_called_once_with(
+                db=db, username=username, password=password, host="mongodb://localhost:27017/?authSource=admin"
+            )
+            self.assertEqual(mongo_conn.db, db)
+
+        mock_disconnect.assert_called_once()
+
+
+class TestPolishNotationToMongoDB(unittest.TestCase):
+
+    def test_single_comparison_operator(self):
+        expression = [("age", "=", 30)]
+        converter = PolishNotationToMongoDB(expression)
+        result = converter.convert()
+        expected = {"age": {"$eq": 30}}
+        self.assertEqual(result, expected)
+
+    def test_multiple_comparison_operator(self):
+        expression = [("age", ">", 20), ("salary", "<", 5000)]
+        converter = PolishNotationToMongoDB(expression)
+        result = converter.convert()
+        expected = {"$and": [{"salary": {"$lt": 5000}}, {"age": {"$gt": 20}}]}
+        self.assertEqual(result, expected)
+
+    def test_logical_operator_and(self):
+        expression = ["and", ("age", ">", 20), ("salary", "<", 5000)]
+        converter = PolishNotationToMongoDB(expression)
+        result = converter.convert()
+        expected = {"$and": [{"age": {"$gt": 20}}, {"salary": {"$lt": 5000}}]}
+        self.assertEqual(result, expected)
+
+    def test_logical_operator_or(self):
+        expression = ["or", ("age", ">", 20), ("salary", "<", 5000)]
+        converter = PolishNotationToMongoDB(expression)
+        result = converter.convert()
+        expected = {"$or": [{"age": {"$gt": 20}}, {"salary": {"$lt": 5000}}]}
+        self.assertEqual(result, expected)
+
+    def test_like_operator(self):
+        expression = [("name", "like", "John")]
+        converter = PolishNotationToMongoDB(expression)
+        result = converter.convert()
+        expected = {"name": {"$regex": "John", "$options": "i"}}
+        self.assertEqual(result, expected)
+
+    def test_nested_logical_operators(self):
+        expression = ["or", ("age", ">", 30), ["and", ("name", "=", "John"), ("salary", ">", 5000)]]
+        converter = PolishNotationToMongoDB(expression)
+        result = converter.convert()
+        expected = {"$or": [{"age": {"$gt": 30}}, {"$and": [{"name": {"$eq": "John"}}, {"salary": {"$gt": 5000}}]}]}
+        self.assertEqual(result, expected)
+
+    def test_invalid_operator(self):
+        expression = [("age", "invalid_op", 30)]
+        converter = PolishNotationToMongoDB(expression)
+        with self.assertRaises(ValueError) as context:
+            converter.convert()
+        self.assertTrue("Unexpected operator: invalid_op" in str(context.exception))
+
+    def test_invalid_token(self):
+        expression = ["invalid_token"]
+        converter = PolishNotationToMongoDB(expression)
+        with self.assertRaises(ValueError) as context:
+            converter.convert()
+        self.assertTrue("Unexpected token: invalid_token" in str(context.exception))
+
+
+class TestDBUtil(unittest.TestCase):
+
+    def setUp(self):
+        self.fields = MagicMock()
+        self.fields.name_field = ["name", "age"]
+
+        self.filter = MagicMock()
+        self.filter.ListFields.return_value = [("some_field",)]
+        self.filter.filter = '[("name", "=", "John")]'
+
+        self.paginated = MagicMock()
+        self.paginated.offset = 1
+        self.paginated.limit = 20
+
+        self.group_by = MagicMock()
+        self.group_by.name_field = ["name"]
+
+        self.sort_by = MagicMock()
+        self.sort_by.name_field = "age"
+        self.sort_by.type = base_pb2.SortBy.ASC
+
+    def test_db_prepared_statement_with_id(self):
+        id = "507f1f77bcf86cd799439011"
+        self.filter.ListFields.return_value = [("id", "=", id)]
+        self.filter.filter = f'[("id", "=", "{id}")]'
+
+        result = DBUtil.db_prepared_statement(id, self.fields, self.filter, self.paginated, self.group_by, self.sort_by)
+
+        expected_result = {
+            "paginated": {"page": 1, "per_page": 20},
+            "filter": {"_id": {"$eq": ObjectId(id)}},
+            "group_by": ["name"],
+            "sort_by": ["+age"],
+            "fields": ["name", "age"],
+            "str_filter": f'[("id", "=", "{id}")]',
+        }
+
+        self.assertEqual(result, expected_result)
+
+    def test_db_prepared_statement_without_filters(self):
+        id = None
+
+        self.filter.ListFields.return_value = [("name", "=", "John")]
+        self.filter.filter = '[("name", "=", "John")]'
+
+        result = DBUtil.db_prepared_statement(id, self.fields, self.filter, self.paginated, self.group_by, self.sort_by)
+
+        expected_result = {
+            "paginated": {"page": 1, "per_page": 20},
+            "filter": {"name": {"$eq": "John"}},
+            "group_by": ["name"],
+            "sort_by": ["+age"],
+            "fields": ["name", "age"],
+            "str_filter": '[("name", "=", "John")]',
+        }
+
+        self.assertEqual(result, expected_result)
+
+    def test_db_prepared_statement_without_id(self):
+        id = None
+        result = DBUtil.db_prepared_statement(id, self.fields, self.filter, self.paginated, self.group_by, self.sort_by)
+
+        expected_result = {
+            "paginated": {"page": 1, "per_page": 20},
+            "filter": {"name": {"$eq": "John"}},
+            "group_by": ["name"],
+            "sort_by": ["+age"],
+            "fields": ["name", "age"],
+            "str_filter": '[("name", "=", "John")]',
+        }
+
+        self.assertEqual(result, expected_result)
+
+    def test_db_trans_sort_asc(self):
+        result = DBUtil.db_trans_sort(self.sort_by)
+        self.assertEqual(result, "+age")
+
+    def test_db_trans_sort_desc(self):
+        self.sort_by.type = base_pb2.SortBy.DESC
+        result = DBUtil.db_trans_sort(self.sort_by)
+        self.assertEqual(result, "-age")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_database_postgres.py
+++ b/tests/test_database_postgres.py
@@ -1,0 +1,378 @@
+import unittest
+from datetime import datetime as DateTime
+from unittest.mock import ANY, MagicMock, patch
+
+from omni.pro.database.postgres import CustomSession, PostgresDatabaseManager, SessionManager
+from sqlalchemy import Column, DateTime, Enum, String, and_
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import operators
+
+Base = declarative_base()
+
+
+class StatusEnum(Enum):
+    FOO = "foo"
+    BAR = "bar"
+
+
+class TestCustomSession(unittest.TestCase):
+
+    def setUp(self):
+        self.session = CustomSession()
+
+    def test_initialization(self):
+        self.assertEqual(self.session.created_attrs, {}, "created_attrs debe inicializarse como un diccionario vacío.")
+        self.assertEqual(self.session.updated_attrs, {}, "updated_attrs debe inicializarse como un diccionario vacío.")
+        self.assertEqual(self.session.deleted_attrs, {}, "deleted_attrs debe inicializarse como un diccionario vacío.")
+        self.assertEqual(self.session.context, {}, "context debe inicializarse como un diccionario vacío.")
+
+    def test_created_attrs_update(self):
+        model_name = "User"
+        instance_id = 1
+        self.session.created_attrs[model_name] = [instance_id]
+
+        self.assertIn(model_name, self.session.created_attrs)
+        self.assertEqual(self.session.created_attrs[model_name], [instance_id])
+
+    def test_updated_attrs_update(self):
+        model_name = "User"
+        instance_id = "1"
+        updated_fields = {"name", "email"}
+
+        self.session.updated_attrs[model_name] = {instance_id: updated_fields}
+
+        self.assertIn(model_name, self.session.updated_attrs)
+        self.assertIn(instance_id, self.session.updated_attrs[model_name])
+        self.assertEqual(self.session.updated_attrs[model_name][instance_id], updated_fields)
+
+    def test_deleted_attrs_update(self):
+        model_name = "User"
+        instance_id = 1
+        self.session.deleted_attrs[model_name] = [instance_id]
+
+        self.assertIn(model_name, self.session.deleted_attrs)
+        self.assertEqual(self.session.deleted_attrs[model_name], [instance_id])
+
+    def test_context_update(self):
+        context_key = "service_url"
+        context_value = "http://example.com/api"
+        self.session.context[context_key] = context_value
+
+        self.assertIn(context_key, self.session.context)
+        self.assertEqual(self.session.context[context_key], context_value)
+
+
+class TestSessionManager(unittest.TestCase):
+
+    @patch("omni.pro.database.postgres.create_engine")
+    @patch("omni.pro.database.postgres.scoped_session")
+    @patch("omni.pro.database.postgres.sessionmaker")
+    def setUp(self, mock_sessionmaker, mock_scoped_session, mock_create_engine):
+        self.base_url = "sqlite:///:memory:"
+        self.session_manager = SessionManager(self.base_url)
+
+        self.mock_session = MagicMock(spec=CustomSession)
+        self.session_manager.Session.return_value = self.mock_session
+
+    def test_session_creation(self):
+
+        with self.session_manager as session:
+            self.assertIs(session, self.mock_session)
+            self.session_manager.Session.assert_called_once()
+
+    def test_commit_on_exit(self):
+        with self.session_manager:
+            pass
+        self.session_manager.Session.commit.assert_called_once()
+        self.session_manager.Session.remove.assert_called_once()
+
+    def test_rollback_on_exception(self):
+        with self.assertRaises(Exception):
+            with self.session_manager:
+                raise Exception("Test exception")
+        self.session_manager.Session.rollback.assert_called_once()
+        self.session_manager.Session.remove.assert_called_once()
+
+    @patch("omni.pro.database.postgres.WebhookHandler.start_thread")
+    def test_pull_crud_attrs(self, mock_start_thread):
+        self.mock_session.context = {"key": "value"}
+        self.mock_session.created_attrs = {"User": [1]}
+        self.mock_session.updated_attrs = {"User": {"1": {"name", "email"}}}
+        self.mock_session.deleted_attrs = {"User": [2]}
+
+        self.session_manager._pull_crud_attrs()
+
+        expected_crud_attrs = {
+            "created_attrs": {"User": [1]},
+            "updated_attrs": {"User": {"1": {"name", "email"}}},
+            "deleted_attrs": {"User": [2]},
+        }
+        expected_context = {"key": "value", "type_db": "sql"}
+
+        mock_start_thread.assert_called_once_with(crud_attrs=expected_crud_attrs, context=expected_context)
+
+    def test_session_commit_on_no_exception(self):
+        with self.session_manager as session:
+            session.commit.assert_not_called()
+
+        self.session_manager.Session.commit.assert_called_once()
+
+    def test_session_rollback_on_exception(self):
+        with self.assertRaises(ValueError):
+            with self.session_manager as session:
+                raise ValueError("Test Error")
+
+        self.session_manager.Session.rollback.assert_called_once()
+
+
+class TestPostgresDatabaseManager(unittest.TestCase):
+
+    @patch("omni.pro.database.postgres.create_engine")
+    @patch("omni.pro.database.postgres.scoped_session")
+    def setUp(self, mock_scoped_session, mock_create_engine):
+        self.name = "test_db"
+        self.host = "localhost"
+        self.port = "5432"
+        self.user = "test_user"
+        self.password = "test_password"
+
+        self.db_manager = PostgresDatabaseManager(self.name, self.host, self.port, self.user, self.password)
+
+        self.mock_engine = MagicMock()
+        mock_create_engine.return_value = self.mock_engine
+        self.mock_session = MagicMock(spec=CustomSession)
+        self.db_manager.Session.return_value = self.mock_session
+        self.session = MagicMock(spec=Session)
+        self.model = MagicMock()
+
+        self.fields = MagicMock()
+        self.filter = MagicMock()
+        self.group_by = MagicMock()
+        self.sort_by = MagicMock()
+        self.paginated = MagicMock()
+
+    def test_init(self):
+        self.assertEqual(self.db_manager.name, self.name)
+        self.assertEqual(self.db_manager.host, self.host)
+        self.assertEqual(self.db_manager.port, self.port)
+        self.assertEqual(self.db_manager.user, self.user)
+        self.assertEqual(self.db_manager.password, self.password)
+        self.assertEqual(
+            self.db_manager.base_url, f"postgresql://{self.user}:{self.password}@{self.host}:{self.port}/{self.name}"
+        )
+
+    @patch("omni.pro.database.postgres.create_engine")
+    def test_get_db_connection(self, mock_create_engine):
+
+        mock_connection = MagicMock()
+
+        mock_create_engine.return_value.connect.return_value = mock_connection
+
+        db_manager = PostgresDatabaseManager(
+            name="test_db", host="localhost", port="5432", user="user", password="password"
+        )
+
+        connection = db_manager.get_db_connection()
+
+        mock_create_engine.return_value.connect.assert_called_once()
+
+        self.assertIs(connection, mock_connection)
+
+    def test_create_new_record(self):
+        mock_model = MagicMock()
+        mock_session = MagicMock()
+
+        record_data = {"name": "Test Record", "value": 100}
+        new_record = self.db_manager.create_new_record(mock_model, mock_session, **record_data)
+
+        mock_model.assert_called_once_with(**record_data)
+        new_record.create.assert_called_once_with(mock_session)
+
+        self.assertEqual(new_record, mock_model.return_value)
+
+    def test_retrieve_record_by_id(self):
+        mock_record = MagicMock()
+        self.session.query(self.model).get.return_value = mock_record
+
+        result = self.db_manager.retrieve_record_by_id(self.model, self.session, 1)
+
+        self.session.query(self.model).get.assert_called_once_with(1)
+        self.assertEqual(result, mock_record)
+
+    def test_retrieve_record(self):
+        mock_record = MagicMock()
+        self.db_manager._retrieve_records = MagicMock(return_value=self.session.query(self.model))
+        self.session.query(self.model).first.return_value = mock_record
+
+        filters = {"name": "test"}
+        result = self.db_manager.retrieve_record(self.model, self.session, filters)
+
+        self.db_manager._retrieve_records.assert_called_once_with(self.model, self.session, filters)
+        self.session.query(self.model).first.assert_called_once()
+        self.assertEqual(result, mock_record)
+
+    def test_retrieve_records(self):
+        mock_records = [MagicMock(), MagicMock()]
+        self.db_manager._retrieve_records = MagicMock(return_value=self.session.query(self.model))
+        self.session.query(self.model).all.return_value = mock_records
+
+        filters = {"name": "test"}
+        result = self.db_manager.retrieve_records(self.model, self.session, filters)
+
+        self.db_manager._retrieve_records.assert_called_once_with(self.model, self.session, filters)
+        self.session.query(self.model).all.assert_called_once()
+        self.assertEqual(result, mock_records)
+
+    def test_retrieve_records_with_or_filters(self):
+        mock_records = [MagicMock(), MagicMock()]
+        self.session.query(self.model).filter.return_value = self.session.query(self.model)
+        self.session.query(self.model).all.return_value = mock_records
+
+        filters = [{"name": "test"}, {"age": 30}]
+        result = self.db_manager._retrieve_records(self.model, self.session, filters)
+
+        self.session.query(self.model).filter.assert_called_once_with(ANY)
+        self.assertEqual(result.all(), mock_records)
+
+    def test_retrieve_records_with_and_filters(self):
+        mock_records = [MagicMock(), MagicMock()]
+        self.session.query(self.model).filter_by.return_value = self.session.query(self.model)
+        self.session.query(self.model).all.return_value = mock_records
+
+        filters = {"name": "test", "age": 30}
+        result = self.db_manager._retrieve_records(self.model, self.session, filters)
+
+        self.session.query(self.model).filter_by.assert_called_once_with(**filters)
+        self.assertEqual(result.all(), mock_records)
+
+    def test_retrieve_records_with_invalid_filters(self):
+        with self.assertRaises(ValueError):
+            self.db_manager._retrieve_records(self.model, self.session, "invalid_filter")
+
+    def test_retrieve_records_with_nested_or_conditions(self):
+        with self.assertRaises(NotImplementedError):
+            filters = [["name", "test"]]
+            self.db_manager._retrieve_records(self.model, self.session, filters)
+
+    def test_list_records_without_id(self):
+        self.paginated.offset = 1
+        self.paginated.limit = 10
+        self.fields.ListFields.return_value = []
+        self.filter.ListFields.return_value = []
+        self.sort_by.ListFields.return_value = []
+
+        records = [MagicMock(), MagicMock()]
+        self.session.query.return_value.offset.return_value.limit.return_value.all.return_value = records
+        self.session.query.return_value.count.return_value = 2
+
+        result, total = self.db_manager.list_records(
+            self.model, self.session, None, self.fields, self.filter, self.group_by, self.sort_by, self.paginated
+        )
+
+        self.session.query(self.model).offset.assert_called_once_with(0)
+        self.session.query(self.model).offset().limit.assert_called_once_with(10)
+        self.assertEqual(result, records)
+        self.assertEqual(total, 2)
+
+    def test_update_record(self):
+        model_id = 1
+        update_dict = {"name": "Updated Name", "age": 30}
+        record = MagicMock()
+
+        self.session.query(self.model).get.return_value = record
+
+        result = self.db_manager.update_record(self.model, self.session, model_id, update_dict)
+
+        self.session.query(self.model).get.assert_called_once_with(model_id)
+        self.assertEqual(record.name, "Updated Name")
+        self.assertEqual(record.age, 30)
+        record.update.assert_called_once_with(self.session)
+        self.assertEqual(result, record)
+
+    def test_update_record_not_found(self):
+        model_id = 1
+        update_dict = {"name": "Updated Name"}
+
+        self.session.query(self.model).get.return_value = None
+
+        result = self.db_manager.update_record(self.model, self.session, model_id, update_dict)
+
+        self.session.query(self.model).get.assert_called_once_with(model_id)
+        self.assertIsNone(result)
+
+    @patch("omni.pro.database.postgres.Session")
+    def test_delete_record_by_id(self, mock_session):
+        mock_record = MagicMock()
+        mock_record.delete.return_value = True
+
+        self.session.query(self.model).filter_by.return_value.first.return_value = mock_record
+
+        result = self.db_manager.delete_record_by_id(self.model, self.session, 1)
+
+        mock_record.delete.assert_called_once_with(self.session)
+        self.assertTrue(result)
+
+    @patch("omni.pro.database.postgres.Session")
+    def test_delete_record_by_id_not_found(self, mock_session):
+        self.session.query(self.model).filter_by.return_value.first.return_value = None
+
+        result = self.db_manager.delete_record_by_id(self.model, self.session, 1)
+
+        self.assertFalse(result)
+
+    def test_get_sqlalchemy_operator(self):
+        self.assertEqual(self.db_manager.get_sqlalchemy_operator("="), operators.eq)
+        self.assertEqual(self.db_manager.get_sqlalchemy_operator("!="), operators.ne)
+        self.assertEqual(self.db_manager.get_sqlalchemy_operator("like"), operators.ilike_op)
+
+        self.assertIsNone(self.db_manager.get_sqlalchemy_operator("unknown_operator"))
+
+    def test_resolve_field_and_joins(self):
+        mock_base_model = MagicMock()
+        mock_related_model = MagicMock()
+        mock_relationship = MagicMock()
+
+        mock_related_field = MagicMock()
+
+        mock_base_model.field1 = mock_relationship
+        mock_relationship.property.mapper.class_ = mock_related_model
+        mock_related_model.field2 = mock_related_field
+
+        field_path = "field1__field2"
+        field, joins = self.db_manager.resolve_field_and_joins(mock_base_model, field_path)
+
+        self.assertIs(field, mock_related_field)
+        self.assertEqual(joins, [mock_relationship])
+
+    def test_parse_expression_simple(self):
+        mock_base_model = MagicMock()
+        mock_base_model.field = Column(String)
+        mock_query = MagicMock()
+
+        self.db_manager.get_sqlalchemy_operator = MagicMock(return_value=operators.eq)
+
+        expression = [("field", "=", "value")]
+
+        result_query = self.db_manager.parse_expression(expression, mock_query, mock_base_model)
+
+        self.db_manager.get_sqlalchemy_operator.assert_any_call("=")
+        mock_query.filter.assert_called_once()
+
+    def test_parse_expression_with_datetime(self):
+        mock_base_model = MagicMock()
+        mock_base_model.created_at = Column(DateTime)
+        mock_query = MagicMock()
+
+        self.db_manager.get_sqlalchemy_operator = MagicMock(return_value=operators.eq)
+
+        expression = [("created_at", "=", "2024-01-01 12:00:00")]
+
+        result_query = self.db_manager.parse_expression(expression, mock_query, mock_base_model)
+
+        self.db_manager.get_sqlalchemy_operator.assert_called_with("=")
+        mock_query.filter.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,86 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from omni.pro.decorators import FunctionThreadController, Resource, resources_decorator
+
+
+class TestResourcesDecorator(unittest.TestCase):
+
+    @patch("omni.pro.decorators.RedisManager")
+    @patch("omni.pro.decorators.AWSCognitoClient")
+    @patch("omni.pro.decorators.AWSS3Client")
+    @patch("omni.pro.decorators.DatabaseManager")
+    @patch("omni.pro.decorators.PostgresDatabaseManager")
+    @patch("omni.pro.response.MessageResponse.internal_response", return_value="response")
+    def test_resources_decorator(
+        self,
+        mock_internal_response,
+        mock_pg_db_manager,
+        mock_db_manager,
+        mock_s3_client,
+        mock_cognito_client,
+        mock_redis_manager,
+    ):
+        mock_redis_instance = MagicMock()
+        mock_redis_manager.return_value = mock_redis_instance
+
+        mock_redis_instance.get_aws_cognito_config.return_value = {"region": "us-west-1"}
+        mock_redis_instance.get_aws_s3_config.return_value = {"bucket": "test-bucket"}
+        mock_redis_instance.get_mongodb_config.return_value = {"name": "test_db", "host": "localhost"}
+        mock_redis_instance.get_postgres_config.return_value = {"name": "test_pg_db", "host": "localhost"}
+
+        resource_list = [Resource.AWS_COGNITO, Resource.AWS_S3, Resource.MONGODB, Resource.POSTGRES]
+
+        @resources_decorator(resource_list)
+        def dummy_func(instance, request, context):
+            return "success"
+
+        request = MagicMock()
+        request.context.user = "test_user"
+        request.context.tenant = "test_tenant"
+        context = MagicMock()
+
+        result = dummy_func(None, request, context)
+
+        mock_cognito_client.assert_called_once_with(region="us-west-1")
+        mock_s3_client.assert_called_once_with(bucket="test-bucket")
+
+        self.assertEqual(context.db_name, "test_pg_db")
+        mock_pg_db_manager.assert_called_once_with(name="test_pg_db", host="localhost")
+
+
+class TestFunctionThreadController(unittest.TestCase):
+
+    def setUp(self):
+        self.controller = FunctionThreadController(timeout=1)
+
+    @patch("threading.Thread")
+    def test_run_thread_controller(self, mock_thread):
+        def dummy_function(arg1, arg2):
+            pass
+
+        wrapped_func = self.controller.run_thread_controller(dummy_function)
+
+        wrapped_func(1, 2)
+
+        self.assertIn("dummy_function", self.controller.function_threads)
+        self.assertTrue(mock_thread.called)
+        thread_instance = self.controller.function_threads["dummy_function"]["thread"]
+        self.assertIsNotNone(thread_instance)
+        thread_instance.start.assert_called_once()
+
+    @patch("queue.Queue")
+    def test_function_queue(self, mock_queue):
+        def dummy_function(arg1, arg2):
+            pass
+
+        mock_queue_instance = MagicMock()
+        mock_queue.return_value = mock_queue_instance
+
+        wrapped_func = self.controller.run_thread_controller(dummy_function)
+
+        wrapped_func(1, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -1,0 +1,106 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import mongomock
+from mongoengine import (
+    Document,
+    EmbeddedDocument,
+    EmbeddedDocumentField,
+    ReferenceField,
+    StringField,
+    connect,
+    disconnect,
+)
+from omni.pro.descriptor import Descriptor
+from sqlalchemy import Column, Enum, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+
+
+class EmbeddedDoc(EmbeddedDocument):
+    embedded_field = StringField()
+
+
+class MongoModel(Document):
+    field1 = StringField(required=True)
+    field2 = ReferenceField("self", required=False)
+    field3 = EmbeddedDocumentField(EmbeddedDoc)
+
+    __is_replic_table__ = True
+
+
+Base = declarative_base()
+
+
+class SQLAlchemyModel(Base):
+    __tablename__ = "test_table"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(50), nullable=False)
+    description = Column(String(200))
+    status = Column(Enum("ACTIVE", "INACTIVE", name="status_enum"))
+
+    @property
+    def __is_replic_table__(self):
+        return True
+
+
+class TestDescriptor(unittest.TestCase):
+
+    def setUp(self):
+        connect("mongoenginetest", host="localhost", mongo_client_class=mongomock.MongoClient)
+
+    def tearDown(self):
+        disconnect()
+
+    @patch("omni.pro.descriptor.Descriptor.get_equivalent_field", return_value="String")
+    @patch("omni.pro.descriptor.inspect")
+    def test_describe_sqlalchemy_model(self, mock_inspect, mock_get_equivalent_field):
+        model = SQLAlchemyModel
+        descriptor = Descriptor()
+
+        mapper_mock = MagicMock()
+        mapper_mock.columns = [
+            Column("id", Integer),
+            Column("name", String),
+            Column("description", String),
+        ]
+        mapper_mock.relationships = {}
+
+        mock_inspect.return_value = mapper_mock
+
+        result = descriptor.describe_sqlalchemy_model(model)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["name"], "SQLAlchemyModel")
+        self.assertIn("fields", result)
+        self.assertEqual(len(result["fields"]), 3)
+
+        field_names = [field["name"] for field in result["fields"]]
+        self.assertIn("Id", field_names)
+        self.assertIn("Name", field_names)
+        self.assertIn("Description", field_names)
+
+    def test_get_equivalent_field(self):
+        descriptor = Descriptor()
+
+        self.assertEqual(descriptor.get_equivalent_field("StringField"), "string")
+        self.assertEqual(descriptor.get_equivalent_field("ReferenceField"), "reference")
+
+        self.assertEqual(descriptor.get_equivalent_field("String"), "string")
+        self.assertEqual(descriptor.get_equivalent_field("Enum"), "enum")
+
+    @patch("omni.pro.descriptor.BaseModel")
+    def test_set_extra_attribute(self, mock_base_model):
+        descriptor = Descriptor()
+
+        column_mock = MagicMock()
+        column_mock.name = "test_column"
+
+        mock_base_model.__annotations__ = {"test_column": MagicMock()}
+        mock_base_model.test_column.column.is_filterable = True
+
+        descriptor.set_extra_attribute(column_mock, "is_filterable")
+        self.assertTrue(column_mock.is_filterable)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -1,0 +1,172 @@
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from omni.pro.import_export import BatchUpsert, ImportExportBase, QueryExport
+
+
+class TestImportExportBase(unittest.TestCase):
+
+    @patch("omni.pro.import_export.import_module")
+    def test_get_model(self, mock_import_module):
+        mock_class = MagicMock()
+        mock_module = MagicMock()
+        mock_import_module.return_value = mock_module
+        mock_module.SomeClass = mock_class
+
+        base = ImportExportBase()
+        result = base.get_model("some.module.SomeClass")
+
+        mock_import_module.assert_called_once_with("some.module")
+        self.assertEqual(result, mock_class)
+
+
+class TestQueryExport(unittest.TestCase):
+
+    def setUp(self):
+        self.context = MagicMock()
+        self.query_export = QueryExport(self.context)
+        self.model = MagicMock()
+        self.model.__tablename__ = "test_table"
+
+    @patch.object(QueryExport, "get_model")
+    @patch.object(QueryExport, "get_data_no_sql")
+    def test_get_data_no_sql(self, mock_get_data_no_sql, mock_get_model):
+        mock_model = MagicMock()
+        mock_get_model.return_value = mock_model
+        mock_get_data_no_sql.return_value = [{"data": "test"}]
+
+        result = self.query_export.get_data(
+            "some.module.SomeModel", ["field1", "field2"], "2024-01-01", "2024-12-31", self.context
+        )
+
+        mock_get_model.assert_called_once_with("some.module.SomeModel")
+        mock_get_data_no_sql.assert_called_once_with(
+            mock_model, "some.module.SomeModel", ["field1", "field2"], "2024-01-01", "2024-12-31", self.context
+        )
+        self.assertEqual(result, [{"data": "test"}])
+
+    @patch.object(QueryExport, "parse_date")
+    def test_parse_date(self, mock_parse_date):
+        mock_parse_date.side_effect = [datetime(2024, 1, 1, 0, 0, 0), datetime(2024, 12, 31, 0, 0, 0)]
+
+        start_date = self.query_export.parse_date("2024-01-01T00:00:00Z")
+        end_date = self.query_export.parse_date("2024-12-31T00:00:00.000Z")
+
+        self.assertEqual(start_date, datetime(2024, 1, 1, 0, 0, 0))
+        self.assertEqual(end_date, datetime(2024, 12, 31, 0, 0, 0))
+
+    @patch.object(QueryExport, "parse_date")
+    def test_get_data_no_sql(self, mock_parse_date):
+        mock_model = MagicMock()
+        mock_model._fields.keys.return_value = {"field1", "field2", "id"}
+
+        mock_db = MagicMock()
+        mock_model.db = mock_db
+
+        expected_result = [{"field1": "value1"}]
+        mock_db.__getitem__.return_value.find.return_value = expected_result
+
+        mock_parse_date.side_effect = [datetime(2024, 1, 1), datetime(2024, 12, 31)]
+
+        result = self.query_export.get_data_no_sql(
+            mock_model, "some.module.SomeModel", ["field1"], "2024-01-01", "2024-12-31", {"tenant": "test_tenant"}
+        )
+
+        mock_db.__getitem__.assert_called_with("somemodel")
+        mock_db.__getitem__.return_value.find.assert_called_once_with(
+            {
+                "context.tenant": "test_tenant",
+                "audit.created_at": {"$gte": datetime(2024, 1, 1), "$lte": datetime(2024, 12, 31)},
+            },
+            projection={"_id": False, "field2": False},
+        )
+
+        self.assertEqual(result, expected_result)
+
+    @patch("omni.pro.import_export.inspect")
+    @patch("omni.pro.import_export.text")
+    @patch.object(QueryExport, "_serialize_query_result")
+    def test_get_data_sql(self, mock_serialize_query_result, mock_text, mock_inspect):
+        mock_inspect.return_value.columns = [
+            MagicMock(name="id", foreign_keys=[]),
+            MagicMock(name="field1", foreign_keys=[]),
+            MagicMock(name="field2", foreign_keys=[]),
+            MagicMock(
+                name="related_id", foreign_keys=[MagicMock(column=MagicMock(table=MagicMock(name="related_table")))]
+            ),
+        ]
+
+        mock_text.return_value = MagicMock()
+        mock_result = MagicMock()
+        self.context.pg_manager.Session.execute.return_value = mock_result
+
+        result = self.query_export.get_data_sql(
+            self.model,
+            "some.module.SomeModel",
+            ["field1", "related_id"],
+            datetime(2024, 1, 1),
+            datetime(2024, 12, 31),
+            {"tenant": "test_tenant"},
+        )
+
+        mock_text.assert_called_once()
+        self.context.pg_manager.Session.execute.assert_called_once_with(
+            mock_text.return_value,
+            {"tenant": "test_tenant", "start_date": datetime(2024, 1, 1), "end_date": datetime(2024, 12, 31)},
+        )
+
+        mock_serialize_query_result.assert_called_once_with(mock_result)
+
+    def test_serialize_query_result(self):
+        mock_result = MagicMock()
+        mock_result.cursor.description = [("id",), ("field1",), ("created_at",)]
+        mock_result.fetchall.return_value = [(1, "value1", datetime(2024, 1, 1))]
+
+        result = self.query_export._serialize_query_result(mock_result)
+
+        expected_result = [
+            {
+                "id": 1,
+                "field1": "value1",
+                "created_at": "2024-01-01T00:00:00",
+            }
+        ]
+        self.assertEqual(result, expected_result)
+
+    def test_datetime_to_string(self):
+        dt = datetime(2024, 1, 1, 10, 30, 45)
+        result = self.query_export.datetime_to_string(dt)
+        self.assertEqual(result, "2024-01-01T10:30:45")
+
+        result = self.query_export.datetime_to_string("not a datetime")
+        self.assertEqual(result, "not a datetime")
+
+
+class TestBatchUpsert(unittest.TestCase):
+
+    def setUp(self):
+        self.context_sql = MagicMock()
+        self.context_sql.pg_manager = MagicMock()
+        self.context_no_sql = MagicMock()
+        self.context_no_sql.db_manager = MagicMock()
+
+        self.batch_upsert_sql = BatchUpsert(context=self.context_sql)
+        self.batch_upsert_no_sql = BatchUpsert(context=self.context_no_sql)
+
+    @patch.object(BatchUpsert, "get_model")
+    def test_upsert_data_sql(self, mock_get_model):
+        mock_model = MagicMock()
+        mock_get_model.return_value = mock_model
+
+        data = {"model_path": "some.module.SomeModel", "upsert_data": [{"id": 1, "field1": "value1"}]}
+
+        result = self.batch_upsert_sql.upsert_data(data)
+
+        self.context_sql.pg_manager.batch_upsert.assert_called_once_with(
+            mock_model, self.context_sql.pg_manager.Session, data
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_initial.py
+++ b/tests/test_initial.py
@@ -1,0 +1,313 @@
+import unittest
+from pathlib import Path
+from unittest.mock import ANY, MagicMock, mock_open, patch
+
+from omni.pro.initial import Event, LoadData, Manifest, ManifestRPCFunction, MicroserviceProto, UserChannel
+
+
+class TestLoadData(unittest.TestCase):
+
+    def setUp(self):
+        self.base_app = Path("/path/to/base/app")
+        self.microservice = "test_microservice"
+        self.persistence_type = "NO_SQL"
+        self.load_data_instance = LoadData(self.base_app, self.microservice, self.persistence_type)
+
+    @patch("omni.pro.initial.RedisManager")
+    @patch("omni.pro.initial.Config")
+    @patch.object(LoadData, "get_rpc_manifest_func_class")
+    @patch("google.protobuf.json_format.MessageToDict")
+    def test_load_data(self, mock_message_to_dict, mock_get_rpc_func, mock_config, mock_redis_manager):
+        mock_redis = MagicMock()
+        mock_redis_manager.return_value = mock_redis
+
+        mock_redis.get_tenant_codes.return_value = ["tenant1", "tenant2"]
+        mock_redis.get_user_admin.side_effect = [{"id": "admin1"}, {"id": "admin2"}]
+        mock_redis.get_postgres_config.return_value = {"name": "pg_db_name"}
+        mock_redis.get_mongodb_config.return_value = {"name": "mongo_db_name"}
+
+        mock_microservice_proto = MagicMock()
+        mock_get_rpc_func.return_value.return_value.get_micro.return_value = MagicMock()
+
+        mock_message_to_dict.return_value = {"code": "test_code", "data": []}
+
+        self.load_data_instance.load_data()
+
+        self.assertEqual(mock_message_to_dict.call_count, 2)
+
+        calls = mock_message_to_dict.call_args_list
+        self.assertIsInstance(calls[0][0][0], MagicMock)
+        self.assertIsInstance(calls[1][0][0], MagicMock)
+
+    @patch("omni.pro.initial.UserChannel")
+    @patch.object(LoadData, "load_data_dict")
+    def test_create_user_admin(self, mock_load_data_dict, mock_user_channel):
+        context = {"tenant": "test_tenant", "user": "admin_user"}
+        mock_rc = MagicMock()
+
+        mock_load_data_dict.return_value = [{"id": "user1", "username": "admin"}]
+
+        mock_user_channel.return_value.create_users.return_value = (
+            MagicMock(user=MagicMock(id="user1", username="admin")),
+            True,
+        )
+
+        response, success = self.load_data_instance.create_user_admin(context, mock_rc)
+
+        mock_user_channel.return_value.create_users.assert_called_once_with(mock_load_data_dict.return_value)
+
+        mock_rc.json().set.assert_called_once_with(
+            context.get("tenant"), "$.user_admin", {"id": response.user.id, "username": response.user.username}
+        )
+        self.assertTrue(success)
+
+    @patch("builtins.open", new_callable=mock_open, read_data="id;name\n1;admin\n2;user")
+    def test_load_data_dict(self, mock_file):
+        file_path = Path("/path/to/file.csv")
+
+        result = list(self.load_data_instance.load_data_dict(file_path))
+
+        expected_result = [{"id": "1", "name": "admin"}, {"id": "2", "name": "user"}]
+        self.assertEqual(result, expected_result)
+        mock_file.assert_called_once_with(file_path, mode="r", encoding="utf-8-sig")
+
+    @patch("omni.pro.initial.PostgresDatabaseManager")
+    @patch.object(LoadData, "csv_to_class")
+    def test_load_data_model(self, mock_csv_to_class, mock_pg_manager):
+        db_pg_params = {"name": "test_db"}
+        context = {"user": "admin", "tenant": "test_tenant"}
+        file_path = "path/to/csv"
+        model_str = "TestModel"
+        mock_modulo = MagicMock()
+
+        mock_model = MagicMock()
+        setattr(mock_modulo, model_str, mock_model)
+
+        self.load_data_instance.load_data_model(db_pg_params, context, file_path, mock_modulo, model_str)
+
+        mock_pg_manager.assert_called_once_with(**db_pg_params)
+        mock_csv_to_class.assert_called_once_with(
+            file_path,
+            mock_model,
+            created_by="admin",
+            updated_by="admin",
+            created_at=ANY,
+            updated_at=ANY,
+            tenant="test_tenant",
+        )
+
+    @patch("omni.pro.initial.ExitStackDocument")
+    @patch.object(LoadData, "csv_to_class")
+    def test_load_data_document(self, mock_csv_to_class, mock_exit_stack):
+        context = {"user": "admin", "tenant": "test_tenant"}
+        file_path = "path/to/csv"
+        db_alias = "tenant_db"
+        model_str = "TestDocument"
+        mock_modulo = MagicMock()
+
+        mock_doc_class = MagicMock()
+        setattr(mock_modulo, model_str, mock_doc_class)
+
+        self.load_data_instance.load_data_document(context, file_path, db_alias, mock_modulo, model_str)
+
+        mock_exit_stack.assert_called_once_with(
+            mock_doc_class.reference_list(), db_alias=db_alias, use_doc_classes=True
+        )
+        mock_csv_to_class.assert_called_once_with(file_path, mock_doc_class, context=context, audit=ANY)
+
+
+class TestManifest(unittest.TestCase):
+
+    def setUp(self):
+        self.base_app = Path("/fake/path")
+        self.manifest_instance = Manifest(self.base_app)
+
+    @patch("builtins.open", new_callable=mock_open, read_data="{'key': 'value'}")
+    @patch("pathlib.Path.exists", return_value=True)
+    def test_get_manifest(self, mock_exists, mock_open_file):
+        result = self.manifest_instance.get_manifest()
+
+        mock_exists.assert_called_once_with()
+        mock_open_file.assert_called_once_with(self.base_app / "__manifest__.py", "r")
+
+        self.assertEqual(result, {"key": "value"})
+
+    @patch("builtins.open", new_callable=mock_open, read_data="{'key': 'value'}")
+    @patch("pathlib.Path.exists", return_value=False)
+    def test_get_manifest_file_not_found(self, mock_exists, mock_open_file):
+        result = self.manifest_instance.get_manifest()
+
+        mock_exists.assert_called_once_with()
+        mock_open_file.assert_not_called()
+
+        self.assertEqual(result, {})
+
+    @patch("omni.pro.initial.MicroServicePathValidator.load", return_value="validated_data")
+    @patch("omni.pro.initial.Manifest.get_manifest", return_value={"code": "test_code"})
+    def test_validate_manifest(self, mock_get_manifest, mock_validator_load):
+        context = {"tenant": "test_tenant", "user": "admin"}
+        micro_data = [{"data": "value"}]
+        micro_settings = [{"settings": "value"}]
+
+        result = self.manifest_instance.validate_manifest(context, {}, micro_data, micro_settings)
+
+        mock_get_manifest.assert_called_once()
+        mock_validator_load.assert_called_once_with(
+            {"code": "test_code", "context": context}, micro_data=micro_data, micro_settings=micro_settings
+        )
+
+        self.assertEqual(result, "validated_data")
+
+
+class TestManifestRPCFunction(unittest.TestCase):
+
+    def setUp(self):
+        self.context = {"tenant": "test_tenant", "user": "admin"}
+        self.manifest_rpc = ManifestRPCFunction(self.context)
+
+    @patch("omni.pro.initial.GRPClient")
+    @patch.object(Event, "update")
+    def test_load_manifest(self, mock_event_update, mock_grpc_client):
+        mock_response = MagicMock()
+        mock_response.microservice.code = "test_microservice"
+        mock_grpc_client.return_value.call_rpc_fuction.return_value = (mock_response, True)
+
+        params = {"param1": "value1"}
+
+        response = self.manifest_rpc.load_manifest(params)
+
+        mock_event_update.assert_called_once_with(
+            rpc_method="MicroserviceCreate",
+            request_class="MicroserviceCreateRequest",
+            params={"param1": "value1", "context": self.context},
+        )
+
+        mock_grpc_client.return_value.call_rpc_fuction.assert_called_once_with(self.manifest_rpc.event)
+
+        self.assertEqual(response, mock_response)
+
+    @patch("omni.pro.initial.GRPClient")
+    @patch.object(Event, "update")
+    def test_get_micro(self, mock_event_update, mock_grpc_client):
+        mock_response = MagicMock()
+        mock_response.microservices = [MicroserviceProto()]
+        mock_grpc_client.return_value.call_rpc_fuction.return_value = (mock_response, True)
+
+        micro = self.manifest_rpc.get_micro("test_code")
+
+        mock_event_update.assert_called_once_with(
+            rpc_method="MicroserviceRead",
+            request_class="MicroserviceReadRequest",
+            params={"filter": {"filter": "[('code','=','test_code')]"}, "context": self.context},
+        )
+
+        mock_grpc_client.return_value.call_rpc_fuction.assert_called_once_with(self.manifest_rpc.event)
+
+        self.assertIsInstance(micro, MicroserviceProto)
+
+    @patch("omni.pro.initial.GRPClient")
+    @patch.object(Event, "update")
+    def test_update_micro(self, mock_event_update, mock_grpc_client):
+        mock_response = MagicMock()
+        mock_response.microservice.code = "test_microservice"
+        mock_grpc_client.return_value.call_rpc_fuction.return_value = (mock_response, True)
+
+        params = {"param1": "value1"}
+
+        response = self.manifest_rpc.update_micro(params)
+
+        mock_event_update.assert_called_once_with(
+            rpc_method="MicroserviceUpdate",
+            request_class="MicroserviceUpdateRequest",
+            params={"param1": "value1", "context": self.context},
+        )
+
+        mock_grpc_client.return_value.call_rpc_fuction.assert_called_once_with(self.manifest_rpc.event)
+
+        self.assertEqual(response, mock_response)
+
+
+class TestUserChannel(unittest.TestCase):
+
+    def setUp(self):
+        self.context = {"tenant": "test_tenant", "user": "admin"}
+        self.user_channel = UserChannel(self.context)
+
+    @patch("omni.pro.initial.GRPClient")
+    @patch.object(Event, "update")
+    def test_create_users(self, mock_event_update, mock_grpc_client):
+        mock_response = MagicMock()
+        mock_response_user_create = MagicMock()
+        mock_response_user_create.user.id = "123"
+        mock_response_user_create.user.username = "test_user"
+        mock_grpc_client.return_value.call_rpc_fuction.return_value = (mock_response_user_create, True)
+
+        list_value = [
+            {
+                "email": "test@example.com",
+                "name": "Test User",
+                "password": "password123",
+                "username": "test_user",
+                "sub": "test_sub",
+            }
+        ]
+
+        response, success = self.user_channel.create_users(list_value)
+
+        mock_event_update.assert_called_once_with(
+            rpc_method="UserCreate",
+            request_class="UserCreateRequest",
+            params={
+                "context": self.context,
+                "email": "test@example.com",
+                "email_confirm": "test@example.com",
+                "language": {"code": "01", "code_name": "CO"},
+                "name": "Test User",
+                "password": "password123",
+                "password_confirm": "password123",
+                "timezone": {"code": "01", "code_name": "CO"},
+                "username": "test_user",
+                "is_superuser": True,
+            },
+        )
+
+        mock_grpc_client.return_value.call_rpc_fuction.assert_called_once_with(self.user_channel.event)
+
+        self.assertEqual(response, mock_response_user_create)
+        self.assertTrue(success)
+
+    @patch("omni.pro.initial.GRPClient")
+    @patch.object(Event, "update")
+    def test_create_users_multiple(self, mock_event_update, mock_grpc_client):
+        mock_response = MagicMock()
+        mock_grpc_client.return_value.call_rpc_fuction.return_value = (mock_response, True)
+
+        list_value = [
+            {
+                "email": "test1@example.com",
+                "name": "Test User 1",
+                "password": "password123",
+                "username": "test_user1",
+                "sub": "test_sub1",
+            },
+            {
+                "email": "test2@example.com",
+                "name": "Test User 2",
+                "password": "password123",
+                "username": "test_user2",
+                "sub": "test_sub2",
+            },
+        ]
+
+        response, success = self.user_channel.create_users(list_value)
+
+        self.assertEqual(mock_event_update.call_count, 2)
+
+        self.assertEqual(mock_grpc_client.return_value.call_rpc_fuction.call_count, 2)
+
+        self.assertEqual(response, mock_response)
+        self.assertTrue(success)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mirror_model.py
+++ b/tests/test_mirror_model.py
@@ -1,0 +1,249 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from omni.pro.mirror_model import MirroModelWebhookRegister, MirrorModelNoSQL, MirrorModelSQL
+from pymongo.operations import InsertOne, UpdateOne
+
+
+class TestMirrorModelSQL(unittest.TestCase):
+
+    def setUp(self):
+        self.context = MagicMock()
+        self.context.pg_manager = MagicMock()
+        self.context.pg_manager.Session = MagicMock()
+        self.tenant = "test_tenant"
+        self.user = "test_user"
+        self.model_path = "omni.pro.mirror_model.MirrorModelSQL"
+
+        self.mirror_model_sql = MirrorModelSQL(self.context, self.model_path, self.tenant, self.user)
+        self.mirror_model_sql.model = MagicMock()
+        self.mirror_model_sql.model.transform_mirror = MagicMock()
+
+    @patch("omni.pro.mirror_model.inspect")
+    def test_create_mirror_model(self, mock_inspect):
+        mock_mapper = MagicMock()
+        mock_column = MagicMock()
+        mock_column.unique = True
+        mock_column.name = "unique_field"
+        mock_column.field_aliasing = "code"
+        mock_mapper.columns = [mock_column]
+        mock_inspect.return_value = mock_mapper
+
+        data = {
+            "model_data": {"unique_field": "value1", "other_field": "value2"},
+            "context": {"tenant": self.tenant, "user": self.user},
+        }
+
+        self.context.pg_manager.retrieve_record.return_value = None
+
+        result = self.mirror_model_sql.create_mirror_model(data)
+
+        self.mirror_model_sql.model.transform_mirror.assert_called_once_with(data["model_data"])
+
+        self.context.pg_manager.create_new_record.assert_called_once_with(
+            self.mirror_model_sql.model,
+            self.context.pg_manager.Session,
+            **data["model_data"],
+            tenant=self.tenant,
+            updated_by=self.user
+        )
+
+    @patch("omni.pro.mirror_model.inspect")
+    def test_update_mirror_model(self, mock_inspect):
+        mock_mapper = MagicMock()
+        mock_column = MagicMock()
+        mock_column.unique = True
+        mock_column.name = "id"
+        mock_mapper.columns = [mock_column]
+        mock_inspect.return_value = mock_mapper
+
+        data = {
+            "model_data": {"id": 1, "other_field": "value2"},
+            "context": {"tenant": self.tenant, "user": self.user},
+        }
+
+        self.context.pg_manager.retrieve_record_by_id.return_value = MagicMock()
+
+        result = self.mirror_model_sql.update_mirror_model(data)
+
+        self.mirror_model_sql.model.transform_mirror.assert_called_once_with(data["model_data"])
+
+        self.context.pg_manager.update_record.assert_called_once_with(
+            self.mirror_model_sql.model,
+            self.context.pg_manager.Session,
+            1,
+            data["model_data"] | {"tenant": self.tenant, "updated_by": self.user},
+        )
+
+    @patch("omni.pro.mirror_model.inspect")
+    def test_multi_create_mirror_model(self, mock_inspect):
+        mock_mapper = MagicMock()
+        mock_column = MagicMock()
+        mock_column.unique = True
+        mock_column.name = "unique_field"
+        mock_column.field_aliasing = "code"
+        mock_mapper.columns = [mock_column]
+        mock_inspect.return_value = mock_mapper
+
+        items = [
+            {"unique_field": "value1", "other_field": "value2"},
+            {"unique_field": "value2", "other_field": "value3"},
+        ]
+
+        self.mirror_model_sql._get_doc_ids_by_unique_field_aliasing = MagicMock(return_value={})
+
+        self.mirror_model_sql.multi_create_mirror_model(items)
+
+        self.mirror_model_sql.model.transform_mirror.assert_any_call(items[0])
+        self.mirror_model_sql.model.transform_mirror.assert_any_call(items[1])
+
+        self.mirror_model_sql.model.bulk_insert.assert_called_once_with(
+            session=self.context.pg_manager.Session, items=items
+        )
+
+    def test_read_mirror_model(self):
+        data = MagicMock()
+        data.id = 1
+        data.fields = ["field1", "field2"]
+        data.filter = {"field1": "value1"}
+        data.group_by = []
+        data.sort_by = []
+        data.paginated = False
+
+        result = self.mirror_model_sql.read_mirror_model(data)
+
+        self.context.pg_manager.list_records.assert_called_once_with(
+            self.mirror_model_sql.model,
+            self.context.pg_manager.Session,
+            data.id,
+            data.fields,
+            data.filter,
+            data.group_by,
+            data.sort_by,
+            data.paginated,
+        )
+
+
+class TestMirrorModelNoSQL(unittest.TestCase):
+
+    def setUp(self):
+        self.context = MagicMock()
+        self.context.db_manager = MagicMock()
+        self.tenant = "test_tenant"
+        self.user = "test_user"
+        self.model_path = "omni.pro.mirror_model.MirrorModelNoSQL"
+
+        self.mirror_model_nosql = MirrorModelNoSQL(self.context, self.model_path, self.tenant, self.user)
+        self.mirror_model_nosql.model = MagicMock()
+        self.mirror_model_nosql.model.transform_mirror = MagicMock()
+
+        self.mirror_model_nosql._get_unique_field_aliasing = MagicMock(return_value="unique_field")
+        self.mirror_model_nosql._get_doc_ids_by_unique_field_aliasing = MagicMock(return_value={})
+
+    def test_create_mirror_model(self):
+        data = {
+            "model_data": {"unique_field": "value1", "other_field": "value2"},
+            "context": {"tenant": self.tenant, "user": self.user},
+        }
+
+        self.context.db_manager.get_document.return_value = None
+
+        result = self.mirror_model_nosql.create_mirror_model(data)
+
+        self.mirror_model_nosql.model.transform_mirror.assert_called_once_with(data["model_data"])
+
+        self.context.db_manager.create_document.assert_called_once_with(
+            None, self.mirror_model_nosql.model, **data["model_data"]
+        )
+
+    def test_multi_create_mirror_model(self):
+        items = [
+            {"unique_field": "value1", "other_field": "value2"},
+            {"unique_field": "value2", "other_field": "value3"},
+        ]
+
+        self.mirror_model_nosql._get_doc_ids_by_unique_field_aliasing = MagicMock(return_value={})
+
+        self.mirror_model_nosql.multi_create_mirror_model(items)
+
+        self.mirror_model_nosql.model.transform_mirror.assert_any_call(items[0])
+        self.mirror_model_nosql.model.transform_mirror.assert_any_call(items[1])
+
+        self.mirror_model_nosql.model._get_collection().bulk_write.assert_called_once_with(
+            [InsertOne(items[0]), InsertOne(items[1])], ordered=False
+        )
+
+    def test_update_mirror_model(self):
+        data = {
+            "model_data": {"id": "existing_doc_id", "other_field": "value2"},
+            "context": {"tenant": self.tenant, "user": self.user},
+        }
+
+        self.context.db_manager.get_document.return_value = MagicMock()
+
+        result = self.mirror_model_nosql.update_mirror_model(data)
+
+        self.mirror_model_nosql.model.transform_mirror.assert_called_once_with(data["model_data"])
+
+        self.context.db_manager.update_document.assert_called_once_with(
+            None, self.mirror_model_nosql.model, **data["model_data"]
+        )
+
+    def test_multi_update_mirror_model(self):
+        items = [
+            {"unique_field": "value1", "other_field": "value2", "id": "doc_id_1"},
+            {"unique_field": "value2", "other_field": "value3", "id": "doc_id_2"},
+        ]
+
+        self.mirror_model_nosql._get_doc_ids_by_unique_field_aliasing = MagicMock(
+            return_value={"value1": "doc_id_1", "value2": "doc_id_2"}
+        )
+
+        self.mirror_model_nosql.multi_update_mirror_model(items)
+
+        self.mirror_model_nosql.model.transform_mirror.assert_any_call(items[0])
+        self.mirror_model_nosql.model.transform_mirror.assert_any_call(items[1])
+
+        self.mirror_model_nosql.model._get_collection().bulk_write.assert_called_once_with(
+            [UpdateOne({"_id": "doc_id_1"}, {"$set": items[0]}), UpdateOne({"_id": "doc_id_2"}, {"$set": items[1]})],
+            ordered=False,
+        )
+
+
+class TestMirroModelWebhookRegister(unittest.TestCase):
+
+    def setUp(self):
+        self.context = {
+            "tenant": "test_tenant",
+            "user": "test_user",
+        }
+
+        self.params = {
+            "filter": {"filter": "[('name', '=', 'test_webhook')]"},
+            "data": {
+                "name": "Test Webhook",
+                "event_ids": [1, 2, 3],
+                "method_grpc_id": 123,
+            },
+        }
+
+    @patch("omni.pro.mirror_model.RedisManager")
+    @patch.object(MirroModelWebhookRegister, "register")
+    def test_run(self, mock_register, mock_redis_manager):
+        mock_redis_instance = mock_redis_manager.return_value
+        mock_redis_instance.get_tenant_codes.return_value = ["tenant1", "tenant2"]
+        mock_redis_instance.get_user_admin.side_effect = [{"id": "user1"}, {"id": "user2"}]
+
+        MirroModelWebhookRegister.run()
+
+        self.assertEqual(mock_register.call_count, 2)
+
+        expected_context_1 = {"tenant": "tenant1", "user": "user1"}
+        expected_context_2 = {"tenant": "tenant2", "user": "user2"}
+
+        mock_register.assert_any_call(context=expected_context_1)
+        mock_register.assert_any_call(context=expected_context_2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_models_base.py
+++ b/tests/test_models_base.py
@@ -1,0 +1,257 @@
+import unittest
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from bson import ObjectId
+from google.protobuf.timestamp_pb2 import Timestamp
+from omni.pro.models.base import (
+    Audit,
+    Base,
+    BaseAuditEmbeddedDocument,
+    BaseDocument,
+    BaseObjectEmbeddedDocument,
+    Context,
+)
+from sqlalchemy import DECIMAL, Boolean, Column, Integer, String, create_engine, inspect
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+BaseModel = declarative_base(cls=Base)
+
+
+class TestModel(BaseModel):
+    __tablename__ = "test_model"
+    id = Column(Integer, primary_key=True)
+    active = Column(Boolean, default=True)
+    name = Column(String(50))
+    price = Column(DECIMAL(10, 2))
+
+
+class TestBaseObjectEmbeddedDocument(unittest.TestCase):
+    def test_to_proto(self):
+        obj = BaseObjectEmbeddedDocument(code="test_code", code_name="test_name")
+
+        proto = obj.to_proto()
+
+        self.assertEqual(proto.code, "test_code")
+        self.assertEqual(proto.code_name, "test_name")
+
+
+class TestAudit(unittest.TestCase):
+    def test_to_proto(self):
+        audit = Audit(
+            created_by="user1", updated_by="user2", created_at=datetime(2023, 1, 1), updated_at=datetime(2023, 1, 2)
+        )
+
+        proto = audit.to_proto()
+
+        self.assertEqual(proto.created_by, "user1")
+        self.assertEqual(proto.updated_by, "user2")
+
+        create_at_ts = Timestamp()
+        create_at_ts.FromDatetime(datetime(2023, 1, 1))
+        update_at_ts = Timestamp()
+        update_at_ts.FromDatetime(datetime(2023, 1, 2))
+
+        self.assertEqual(proto.created_at, create_at_ts)
+        self.assertEqual(proto.updated_at, update_at_ts)
+
+
+class TestContext(unittest.TestCase):
+    def test_to_proto(self):
+        context = Context(tenant="test_tenant", user="test_user")
+
+        proto = context.to_proto()
+
+        self.assertEqual(proto.tenant, "test_tenant")
+        self.assertEqual(proto.user, "test_user")
+
+
+class TestBaseDocument(unittest.TestCase):
+    def setUp(self):
+        self.context = Context(tenant="test_tenant", user="test_user")
+        self.audit = Audit(created_by="test_user", updated_by="test_user")
+        self.document = BaseDocument(context=self.context, audit=self.audit, active=True)
+        self.document._collection = MagicMock()
+        self.document._collection.name = "test_collection"
+        self.document.id = ObjectId("507f1f77bcf86cd799439011")
+        self.document._changed_fields = ["field1"]
+
+    def test_generate_dict(self):
+        self.document.id = ObjectId("507f1f77bcf86cd799439011")
+
+        with patch.object(self.document, "to_mongo") as mock_to_mongo:
+            mock_to_mongo.return_value.to_dict.return_value = {
+                "_id": ObjectId("507f1f77bcf86cd799439011"),
+                "context": {"tenant": "test_tenant", "user": "test_user"},
+                "audit": {
+                    "created_at": datetime(2024, 10, 8, 15, 4, 16),
+                    "created_by": "test_user",
+                    "updated_at": datetime(2024, 10, 8, 15, 4, 16),
+                    "updated_by": "test_user",
+                },
+                "active": True,
+            }
+
+            generated_dict = self.document.generate_dict()
+
+            self.assertIn("id", generated_dict)
+            self.assertEqual(generated_dict["id"], "507f1f77bcf86cd799439011")
+
+    @patch("omni.pro.models.base.Context")
+    @patch("omni.pro.models.base.Audit")
+    def test_save(self, mock_audit, mock_context):
+        mock_audit.return_value = Audit(created_by="test_user")
+        mock_context.return_value = self.context
+
+        with patch.object(BaseDocument, "save", return_value=None) as mock_save:
+            self.document.save()
+
+            self.assertEqual(self.document.audit.updated_by, "test_user")
+            self.assertIsNotNone(self.document.audit.updated_at)
+            mock_save.assert_called_once()
+
+    def test_update(self):
+        with patch.object(BaseDocument, "update", return_value=None) as mock_update:
+            self.document.update(name="New Name")
+            mock_update.assert_called_once()
+
+    @patch("omni.pro.models.base.BaseDocument.assign_crud_attrs_to_stack")
+    @patch("omni.pro.models.base.Config")
+    def test_post_save_create(self, mock_config, mock_crud_attrs):
+        mock_config.PROCESS_WEBHOOK = True
+        BaseDocument.post_save(sender=BaseDocument, document=self.document, created=True)
+
+        mock_crud_attrs.assert_called_once_with("create")
+
+    @patch("omni.pro.models.base.BaseDocument.assign_crud_attrs_to_stack")
+    @patch("omni.pro.models.base.Config")
+    def test_post_save_update(self, mock_config, mock_crud_attrs):
+        mock_config.PROCESS_WEBHOOK = True
+        BaseDocument.post_save(sender=BaseDocument, document=self.document, created=False)
+
+        mock_crud_attrs.assert_called_once_with("update", {"field1"})
+
+    @patch("omni.pro.models.base.BaseDocument.assign_crud_attrs_to_stack")
+    @patch("omni.pro.models.base.Config")
+    def test_post_delete(self, mock_config, mock_crud_attrs):
+        mock_config.PROCESS_WEBHOOK = True
+        BaseDocument.post_delete(sender=BaseDocument, document=self.document)
+
+        mock_crud_attrs.assert_called_once_with("delete")
+
+    def test_assign_crud_attrs_to_stack_create(self):
+        self.document.created_attrs = {}
+        self.document.assign_crud_attrs_to_stack(action="create")
+        self.assertIn(self.document._collection.name, self.document.created_attrs)
+
+
+class TestBaseAuditEmbeddedDocument(unittest.TestCase):
+
+    def setUp(self):
+        self.document = BaseAuditEmbeddedDocument(
+            context=Context(tenant="test_tenant", user="test_user"), audit=Audit(created_by="initial_user")
+        )
+
+    @patch("omni.pro.models.base.datetime")
+    def test_audit_fields_are_updated(self, mock_datetime):
+        mock_datetime.utcnow.return_value = datetime(2024, 1, 1, 12, 0, 0)
+
+        self.document.update_audit_fields()
+
+        self.assertEqual(self.document.audit.created_by, "initial_user")
+        self.assertEqual(self.document.audit.updated_by, "test_user")
+        self.assertEqual(self.document.audit.updated_at, datetime(2024, 1, 1, 12, 0, 0))
+
+    def test_context_is_set_if_not_present(self):
+        document = BaseAuditEmbeddedDocument(audit=Audit(created_by="initial_user"))
+
+        document.update_audit_fields()
+
+        self.assertIsNotNone(document.context)
+        self.assertIsNotNone(document.context.tenant)
+
+    def test_context_is_set_if_not_present(self):
+        document = BaseAuditEmbeddedDocument()
+
+        document.context = Context(tenant="default_tenant", user="default_user")
+
+        document.update_audit_fields()
+
+        self.assertIsNotNone(document.context)
+        self.assertEqual(document.context.tenant, "default_tenant")
+        self.assertEqual(document.context.user, "default_user")
+
+    def test_active_field_defaults_to_true(self):
+        document = BaseAuditEmbeddedDocument()
+
+        self.assertTrue(document.active)
+
+    def test_external_id_can_be_set(self):
+        document = BaseAuditEmbeddedDocument(external_id="test_external_id")
+
+        self.assertEqual(document.external_id, "test_external_id")
+
+
+class TestBaseModel(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        BaseModel.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+        self.session = self.Session()
+
+        self.instance = TestModel(
+            id=1,
+            active=True,
+            name="Test Item",
+            price=Decimal("19.99"),
+            external_id="ext_123",
+            tenant="tenant_1",
+            created_by="user_1",
+            updated_by="user_2",
+            created_at=datetime(2024, 1, 1, 10, 0),
+            updated_at=datetime(2024, 1, 2, 10, 0),
+        )
+        self.session.add(self.instance)
+        self.session.commit()
+
+        self.session = MagicMock(spec=Session)
+
+    def test_create_method(self):
+        result = self.instance.create(self.session)
+        self.session.add.assert_called_once_with(self.instance)
+        self.session.flush.assert_called_once()
+        self.assertEqual(result, self.instance)
+
+    def test_bulk_insert_method(self):
+        items = [{"field1": "value1"}, {"field1": "value2"}]
+        Base.bulk_insert(self.session, items)
+        self.session.bulk_insert_mappings.assert_called_once_with(Base, items)
+        self.session.flush.assert_called_once()
+
+    def test_bulk_update_method(self):
+        items = [{"field1": "value1"}, {"field1": "value2"}]
+        Base.bulk_update(self.session, items)
+        self.session.bulk_update_mappings.assert_called_once_with(Base, items)
+        self.session.flush.assert_called_once()
+
+    def test_update_method(self):
+        self.instance.update(self.session)
+        self.session.flush.assert_called_once()
+        self.session.refresh.assert_called_once_with(self.instance)
+
+    def test_delete_method_success(self):
+        result = self.instance.delete(self.session)
+        self.session.delete.assert_called_once_with(self.instance)
+        self.assertTrue(result)
+
+    def test_delete_method_failure(self):
+        self.session.delete.side_effect = SQLAlchemyError
+        result = self.instance.delete(self.session)
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import patch
+
+from omni.pro.register import RegisterModel
+
+
+class TestRegisterModel(unittest.TestCase):
+
+    def setUp(self):
+        self.models_path = "path/to/models"
+        self.microservice = "test_microservice"
+        self.register_model = RegisterModel(self.models_path, self.microservice)
+
+    def test_transform_field_desc(self):
+        mock_field = {"name": "test_field", "code": "test_code", "type": "string", "required": True, "relation": {}}
+
+        result = self.register_model.transform_field_desc(mock_field)
+
+        self.assertEqual(result["name"], "test_field")
+        self.assertEqual(result["code"], "test_code")
+        self.assertEqual(result["type"], "string")
+        self.assertEqual(result["required"], True)
+        self.assertEqual(result["relation"], {})
+
+    def test_transform_field_desc_with_options_and_size(self):
+        mock_field = {
+            "name": "test_field",
+            "code": "test_code",
+            "type": "string",
+            "required": True,
+            "relation": {},
+            "size": 255,
+            "options": ["option1", "option2"],
+        }
+
+        result = self.register_model.transform_field_desc(mock_field)
+
+        self.assertEqual(result["size"], 255)
+        self.assertEqual(result["options"], ["option1", "option2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,169 @@
+import unittest
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+from omni.pro.response import MessageCode, MessageResponse
+from omni_pro_grpc.common import base_pb2
+
+
+class TestMessageResponse(unittest.TestCase):
+
+    def setUp(self):
+        self.response_class = MagicMock()
+        self.message_response = MessageResponse(self.response_class)
+
+    def test_response(self):
+        result = self.message_response.response(
+            message="Test Message", success=True, status_code=HTTPStatus.OK, message_code=MessageCode.RESOURCE_READ
+        )
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=True,
+                message="Test Message",
+                status_code=HTTPStatus.OK,
+                message_code=MessageCode.RESOURCE_READ,
+            ),
+        )
+
+    def test_input_validator_response(self):
+        result = self.message_response.input_validator_response(message="Invalid Input")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=False,
+                message="Invalid Input",
+                status_code=HTTPStatus.BAD_REQUEST,
+                message_code=MessageCode.INPUT_VALIDATOR_ERROR,
+            ),
+        )
+
+    def test_created_response(self):
+        result = self.message_response.created_response(message="Resource Created")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=True,
+                message="Resource Created",
+                status_code=HTTPStatus.CREATED,
+                message_code=MessageCode.RESOURCE_CREATED,
+            ),
+        )
+
+    def test_deleted_response(self):
+        result = self.message_response.deleted_response(message="Resource Deleted")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=True,
+                message="Resource Deleted",
+                status_code=HTTPStatus.OK,
+                message_code=MessageCode.RESOURCE_DELETED,
+            ),
+        )
+
+    def test_updated_response(self):
+        result = self.message_response.updated_response(message="Resource Updated")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=True,
+                message="Resource Updated",
+                status_code=HTTPStatus.OK,
+                message_code=MessageCode.RESOURCE_UPDATED,
+            ),
+        )
+
+    def test_fetched_response(self):
+        paginated = base_pb2.Paginated(limit=10, offset=0)
+        result = self.message_response.fetched_response(
+            message="Resources Fetched",
+            paginated=paginated,
+            total=5,
+            count=5,
+        )
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=True,
+                message="Resources Fetched",
+                status_code=HTTPStatus.OK,
+                message_code=MessageCode.RESOURCE_FETCHED,
+            ),
+            meta_data=base_pb2.MetaData(limit=10, offset=0, total=5, count=5),
+        )
+
+    def test_internal_response(self):
+        result = self.message_response.internal_response(message="Internal Server Error")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=False,
+                message="Internal Server Error",
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                message_code=MessageCode.INTERNAL_SERVER_ERROR,
+            ),
+        )
+
+    def test_already_exists_response(self):
+        result = self.message_response.already_exists_response(message="Resource Already Exists")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=False,
+                message="Resource Already Exists",
+                status_code=HTTPStatus.OK,
+                message_code=MessageCode.RESOURCE_ALREADY_EXISTS,
+            ),
+        )
+
+    def test_not_found_response(self):
+        result = self.message_response.not_found_response(message="Resource Not Found")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=False,
+                message="Resource Not Found",
+                status_code=HTTPStatus.NOT_FOUND,
+                message_code=MessageCode.RESOURCE_NOT_FOUND,
+            ),
+        )
+
+    def test_unauthorized_response(self):
+        result = self.message_response.unauthorized_response(message="User Unauthorized")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=False,
+                message="User Unauthorized",
+                status_code=HTTPStatus.UNAUTHORIZED,
+                message_code=MessageCode.USER_UNAUTHORIZED,
+            ),
+        )
+
+    def test_method_not_allowed_response(self):
+        result = self.message_response.method_not_allowed_response(message="Method Not Allowed")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=False,
+                message="Method Not Allowed",
+                status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+                message_code=MessageCode.USER_UNAUTHORIZED,
+            ),
+        )
+
+    def test_success_response(self):
+        result = self.message_response.success_response(message="Success")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=True,
+                message="Success",
+                status_code=HTTPStatus.OK,
+                message_code=MessageCode.RESOURCE_READ,
+            ),
+        )
+
+    def test_import_export_processing_response(self):
+        result = self.message_response.import_export_processing_response(message="Processing")
+        self.response_class.assert_called_once_with(
+            response_standard=base_pb2.ResponseStandard(
+                success=True,
+                message="Processing",
+                status_code=HTTPStatus.CREATED,
+                message_code=MessageCode.IMPORT_EXPORT_PROCESSING,
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from omni.pro.stack import ExitStackDocument, ExitStackDocumentMicro
+
+
+class TestExitStackDocument(unittest.TestCase):
+
+    def setUp(self):
+        self.document_class_1 = MagicMock()
+        self.document_class_2 = MagicMock()
+        self.document_classes = [self.document_class_1, self.document_class_2]
+        self.db_alias = "test_db"
+        self.context = {"user": "test_user", "tenant": "test_tenant"}
+
+    @patch("omni.pro.stack.ctx_mgr.switch_db")
+    def test_enter_creates_collections_and_switches_db(self, mock_switch_db):
+        with ExitStackDocument(self.document_classes, self.db_alias, self.context) as stack:
+            mock_switch_db.assert_any_call(self.document_class_1, self.db_alias)
+            mock_switch_db.assert_any_call(self.document_class_2, self.db_alias)
+            self.document_class_1._meta.__setitem__.assert_called_with("db_alias", self.db_alias)
+            self.document_class_1.db.list_collection_names.assert_called_once()
+            self.document_class_1.db.create_collection.assert_called_once()
+
+    @patch("omni.pro.stack.WebhookHandler.start_thread")
+    def test_exit_pulls_crud_attrs_and_starts_webhook_thread(self, mock_start_thread):
+        with ExitStackDocument(self.document_classes, self.db_alias, self.context) as stack:
+            stack.created_attrs = {"doc1": [1, 2, 3]}
+            stack.updated_attrs = {"doc1": {"field1": {"value1"}}}
+            stack.deleted_attrs = {"doc1": [4, 5, 6]}
+
+        expected_crud_attrs = {
+            "created_attrs": {"doc1": [1, 2, 3]},
+            "updated_attrs": {"doc1": {"field1": {"value1"}}},
+            "deleted_attrs": {"doc1": [4, 5, 6]},
+        }
+        self.context["type_db"] = "document"
+        mock_start_thread.assert_called_once_with(crud_attrs=expected_crud_attrs, context=self.context)
+
+
+class TestExitStackDocumentMicro(unittest.TestCase):
+
+    @patch("omni.pro.stack.Topology.get_models_from_libs", return_value=[MagicMock(), MagicMock()])
+    @patch("omni.pro.stack.ctx_mgr.switch_db")
+    @patch("importlib.import_module")
+    def test_enter_switches_to_all_models_in_services(self, mock_import_module, mock_switch_db, mock_get_models):
+        mock_import_module.return_value = MagicMock()
+
+        db_alias = "microservice_db"
+        with ExitStackDocumentMicro(db_alias) as stack:
+            mock_switch_db.assert_any_call(mock_get_models.return_value[0], db_alias)
+            mock_switch_db.assert_any_call(mock_get_models.return_value[1], db_alias)
+
+    @patch("omni.pro.stack.Topology.get_models_from_libs", return_value=[MagicMock(), MagicMock()])
+    @patch("omni.pro.stack.ctx_mgr.switch_db")
+    @patch("omni.pro.stack.WebhookHandler.start_thread")
+    @patch("importlib.import_module")
+    def test_exit_with_models_from_services(
+        self, mock_import_module, mock_start_thread, mock_switch_db, mock_get_models
+    ):
+        mock_import_module.return_value = MagicMock()
+
+        context = {"tenant": "test_tenant", "user": "test_user"}
+        with ExitStackDocumentMicro("microservice_db", context=context) as stack:
+            stack.created_attrs = {"model_1": [1, 2]}
+            stack.updated_attrs = {"model_2": {"field1": {"value1"}}}
+            stack.deleted_attrs = {"model_1": [3, 4]}
+
+        expected_crud_attrs = {
+            "created_attrs": {"model_1": [1, 2]},
+            "updated_attrs": {"model_2": {"field1": {"value1"}}},
+            "deleted_attrs": {"model_1": [3, 4]},
+        }
+        context["type_db"] = "document"
+        mock_start_thread.assert_called_once_with(crud_attrs=expected_crud_attrs, context=context)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_template_loader.py
+++ b/tests/test_template_loader.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest.mock import patch
+
+from omni.pro.template.loader import render_to_string
+
+
+class TestRenderToString(unittest.TestCase):
+
+    @patch("jinja2.Template.render")
+    def test_render_to_string(self, mock_render):
+        template_name = "Hello, {{ name }}!"
+        context = {"name": "World"}
+
+        mock_render.return_value = "Hello, World!"
+
+        result = render_to_string(template_name, context)
+
+        mock_render.assert_called_once_with(context)
+
+        self.assertEqual(result, "Hello, World!")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from omni.pro.topology import Topology
+
+
+class TestTopology(unittest.TestCase):
+
+    @patch("importlib.import_module")
+    def setUp(self, mock_import_module):
+        self.mock_models = MagicMock()
+        self.mock_models.__path__ = ["path_to_models"]
+        mock_import_module.return_value = self.mock_models
+        self.topology = Topology()
+
+    @patch("pkgutil.iter_modules")
+    def test_get_model_libs(self, mock_iter_modules):
+        mock_iter_modules.return_value = [(None, "module1", None), (None, "module2", None)]
+
+        result = self.topology.get_model_libs()
+
+        self.assertEqual(result, ["module1", "module2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_user_access.py
+++ b/tests/test_user_access.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from omni.pro.models.base import BaseModel
+from omni.pro.user.access import Permission, permission_required
+from omni_pro_grpc.v1.users import user_pb2
+
+
+class MockResponseClass:
+    def __init__(self, cls):
+        self.cls = cls
+
+    def unauthorized_response(self):
+        return {"status_code": 401}
+
+    def internal_response(self, message):
+        return {"status_code": 500, "message": message}
+
+
+class TestPermissionRequiredDecorator(unittest.TestCase):
+
+    def setUp(self):
+        self.request = MagicMock()
+        self.request.context.user = "test_user"
+        self.request.context.tenant = "test_tenant"
+        self.context = MagicMock()
+
+        self.grpc_response = user_pb2.HasPermissionResponse(has_permission=True)
+        self.success_response = (self.grpc_response, True)
+
+    @patch("omni.pro.user.access.GRPClient.call_rpc_fuction")
+    @patch("omni.pro.response.MessageResponse", return_value=MockResponseClass(BaseModel))
+    def test_permission_granted(self, mock_message_response, mock_grpc_call):
+        mock_grpc_call.return_value = self.success_response
+
+        @permission_required(Permission.CAN_CREATE_USER, BaseModel)
+        def sample_function(instance, request, context):
+            return "Access Granted"
+
+        result = sample_function(self, self.request, self.context)
+
+        self.assertEqual(result, "Access Granted")
+        mock_grpc_call.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pkg_resources
+from google.protobuf import struct_pb2
+from omni.pro.util import convert_model_alchemy_to_struct, convert_model_mongo_to_struct, libraries_versions_installed
+
+
+class TestUtilities(unittest.TestCase):
+
+    @patch("pkg_resources.get_distribution")
+    def test_libraries_versions_installed(self, mock_get_distribution):
+        mock_get_distribution.side_effect = [
+            MagicMock(version="1.0.0"),
+            MagicMock(version="2.0.0"),
+            MagicMock(version="3.0.0"),
+            MagicMock(version="4.0.0"),
+        ]
+
+        result = libraries_versions_installed()
+
+        expected_result = {
+            "omni_pro": "1.0.0",
+            "omni_pro_base": "2.0.0",
+            "omni_pro_redis": "3.0.0",
+            "omni_pro_grpc": "4.0.0",
+        }
+
+        self.assertEqual(result, expected_result)
+        mock_get_distribution.assert_any_call("omni-pro")
+        mock_get_distribution.assert_any_call("omni-pro-base")
+        mock_get_distribution.assert_any_call("omni-pro-redis")
+        mock_get_distribution.assert_any_call("omni-pro-grpc")
+
+    @patch("pkg_resources.get_distribution")
+    def test_libraries_versions_not_installed(self, mock_get_distribution):
+        mock_get_distribution.side_effect = [
+            MagicMock(version="1.0.0"),
+            pkg_resources.DistributionNotFound,
+            pkg_resources.DistributionNotFound,
+            MagicMock(version="4.0.0"),
+        ]
+
+        result = libraries_versions_installed()
+
+        expected_result = {
+            "omni_pro": "1.0.0",
+            "omni_pro_base": "Not installed",
+            "omni_pro_redis": "Not installed",
+            "omni_pro_grpc": "4.0.0",
+        }
+
+        self.assertEqual(result, expected_result)
+
+    @patch("omni.pro.util.convert_to_serializable")
+    @patch("omni.pro.util.json_format.ParseDict")
+    def test_convert_model_alchemy_to_struct(self, mock_parse_dict, mock_convert_to_serializable):
+        mock_model = MagicMock()
+        mock_model.model_to_dict.return_value = {"field": "value"}
+        mock_convert_to_serializable.return_value = {"field": "value"}
+        mock_struct = MagicMock()
+        mock_parse_dict.return_value = mock_struct
+
+        result = convert_model_alchemy_to_struct(mock_model)
+
+        mock_model.model_to_dict.assert_called_once()
+        mock_convert_to_serializable.assert_called_once_with({"field": "value"})
+        mock_parse_dict.assert_called_once_with({"field": "value"}, struct_pb2.Struct())
+        self.assertEqual(result, mock_struct)
+
+    @patch("omni.pro.util.convert_to_serializable")
+    @patch("omni.pro.util.json_format.ParseDict")
+    def test_convert_model_mongo_to_struct(self, mock_parse_dict, mock_convert_to_serializable):
+        mock_model = MagicMock()
+        mock_model.generate_dict.return_value = {"field": "value"}
+        mock_convert_to_serializable.return_value = {"field": "value"}
+        mock_struct = MagicMock()
+        mock_parse_dict.return_value = mock_struct
+
+        result = convert_model_mongo_to_struct(mock_model)
+
+        mock_model.generate_dict.assert_called_once()
+        mock_convert_to_serializable.assert_called_once_with({"field": "value"})
+        mock_parse_dict.assert_called_once_with({"field": "value"}, struct_pb2.Struct())
+        self.assertEqual(result, mock_struct)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,145 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from bson import ObjectId
+from marshmallow import ValidationError
+from omni.pro.validators import (
+    ContextSchema,
+    MicroServicePathValidator,
+    ObjectIdField,
+    PostgresBaseSchema,
+    ensure_objid_type,
+    oid_isval,
+)
+
+
+class TestSchemas(unittest.TestCase):
+
+    def test_context_schema_validation(self):
+        schema = ContextSchema()
+        valid_data = {"tenant": "tenant_id", "user": "user_id"}
+        result = schema.load(valid_data)
+        self.assertEqual(result["tenant"], "tenant_id")
+        self.assertEqual(result["user"], "user_id")
+
+        invalid_data = {"tenant": "tenant_id"}
+        with self.assertRaises(ValidationError):
+            schema.load(invalid_data)
+
+    def test_postgres_base_schema(self):
+        schema = PostgresBaseSchema()
+        data = {
+            "active": True,
+            "context": {"tenant": "tenant_id", "user": "user_id"},
+        }
+        result = schema.load(data)
+        self.assertEqual(result["tenant"], "tenant_id")
+        self.assertEqual(result["updated_by"], "user_id")
+
+    def test_oid_isval_valid(self):
+        oid = ObjectId()
+        self.assertTrue(oid_isval(oid))
+
+    def test_oid_isval_invalid(self):
+        self.assertFalse(oid_isval("invalid_oid"))
+
+    def test_ensure_objid_type_valid(self):
+        oid = ObjectId()
+        self.assertEqual(ensure_objid_type(oid), oid)
+
+        oid_str = str(oid)
+        self.assertEqual(ensure_objid_type(oid_str), oid)
+
+    def test_ensure_objid_type_invalid(self):
+        with self.assertRaises(ValidationError):
+            ensure_objid_type("invalid_oid")
+
+    def test_object_id_field_serialize(self):
+        field = ObjectIdField()
+        oid = ObjectId()
+        result = field._serialize(oid, "oid", None)
+        self.assertEqual(result, oid)
+
+    def test_object_id_field_deserialize_valid(self):
+        field = ObjectIdField()
+        oid_str = str(ObjectId())
+        result = field._deserialize(oid_str, "oid", None)
+        self.assertTrue(isinstance(result, ObjectId))
+
+    def test_object_id_field_deserialize_invalid(self):
+        field = ObjectIdField()
+        with self.assertRaises(ValidationError):
+            field._deserialize("invalid_oid", "oid", None)
+
+
+class TestMicroServicePathValidator(unittest.TestCase):
+
+    @patch("pathlib.Path.exists")
+    def test_validate_data_success(self, mock_exists):
+        mock_exists.return_value = True
+        base_app = MagicMock()
+        schema = MicroServicePathValidator(base_app)
+
+        data = {
+            "name": "Test Service",
+            "code": "test_service",
+            "sumary": "Test Summary",
+            "description": "Test Description",
+            "version": "1.0.0",
+            "author": "Test Author",
+            "category": "Test Category",
+            "context": {"tenant": "test_tenant", "user": "test_user"},
+            "data": ["path1", "path2"],
+        }
+
+        schema.load(data)
+
+    @patch("pathlib.Path.exists")
+    def test_validate_data_file_not_found(self, mock_exists):
+        mock_exists.side_effect = [True, False]
+        base_app = MagicMock()
+        schema = MicroServicePathValidator(base_app)
+
+        data = {"data": ["path1", "path2"]}
+        with self.assertRaises(ValidationError):
+            schema.load(data)
+
+    def test_validate_duplicate_elements(self):
+        base_app = MagicMock()
+        schema = MicroServicePathValidator(base_app)
+
+        data = ["path1", "path2", "path1"]
+        duplicates = schema._duplicate_elements(data)
+        self.assertEqual(duplicates, ["path1"])
+
+    def test_load_micro_service_data_and_settings(self):
+        base_app = MagicMock()
+        schema = MicroServicePathValidator(base_app)
+
+        micro_settings = [{"code": "setting1", "value": "default"}]
+        micro_data = [{"path": "path1"}]
+        data = {
+            "name": "Test Service",
+            "code": "test_service",
+            "sumary": "Test Summary",
+            "description": "Test Description",
+            "version": "1.0.0",
+            "author": "Test Author",
+            "category": "Test Category",
+            "context": {"tenant": "test_tenant", "user": "test_user"},
+            "data": ["path1", "path2"],
+            "settings": [{"code": "setting1"}, {"code": "setting2"}],
+        }
+
+        result = schema.load(data, micro_settings=micro_settings, micro_data=micro_data)
+
+        expected_data = [
+            {"path": "path1"},
+            {"path": "path2", "load": False},
+        ]
+        self.assertEqual(result["data"], expected_data)
+        self.assertEqual(len(result["settings"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_webhook_handler.py
+++ b/tests/test_webhook_handler.py
@@ -1,0 +1,506 @@
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import requests
+from omni.pro.redis import RedisManager
+from omni.pro.webhook.webhook_handler import WebhookHandler
+
+
+class TestWebhookHandler(unittest.TestCase):
+
+    def setUp(self):
+        self.crud_attrs = {
+            "created_attrs": {"test_model": [1, 2]},
+            "updated_attrs": {"test_model": {"1": {"field1"}}},
+            "deleted_attrs": {"test_model": [3]},
+        }
+        self.context = {"tenant": "test_tenant", "user": "test_user", "type_db": "sql"}
+
+        # Mocks para RedisManager, Config y Celery
+        self.mock_redis_manager = MagicMock()
+        self.mock_celery_app = MagicMock()
+
+        with patch("omni.pro.webhook.webhook_handler.RedisManager", return_value=self.mock_redis_manager), patch(
+            "omni.pro.webhook.webhook_handler.CeleryRedis.get_celery_app_by_tenant", return_value=self.mock_celery_app
+        ), patch("omni.pro.webhook.webhook_handler.Config") as MockConfig:
+
+            # Configurar Mock para el objeto Config
+            MockConfig.REDIS_HOST = "localhost"
+            MockConfig.REDIS_PORT = 6379
+            MockConfig.REDIS_DB = 0
+            MockConfig.REDIS_SSL = False
+
+            # Inicializar WebhookHandler
+            self.handler = WebhookHandler(self.crud_attrs, self.context)
+            self.handler.tenant = "test_tenant"
+            self.handler.user = "test_user"
+            self.handler.session = MagicMock()
+            self.handler.class_by_name = {"TestModel": MagicMock()}
+            self.handler.paginated_limit = 100
+            self.handler.rpc_webhook = MagicMock()
+            self.handler.rpc_event = MagicMock()
+            self.handler.rpc_model = MagicMock()
+
+    @patch("omni.pro.webhook.webhook_handler.RedisManager")
+    @patch("omni.pro.webhook.webhook_handler.CeleryRedis.get_celery_app_by_tenant")
+    def test_init_with_valid_data(self, mock_get_celery_app, mock_redis_manager):
+        mock_get_celery_app.return_value = MagicMock()
+        mock_redis_manager.return_value = MagicMock()
+
+        handler = WebhookHandler(self.crud_attrs, self.context)
+
+        self.assertEqual(handler.tenant, "test_tenant")
+        self.assertEqual(handler.user, "test_user")
+        self.assertEqual(handler.created_attrs, {"test_model": [1, 2]})
+        self.assertEqual(handler.updated_attrs, {"test_model": {"1": {"field1"}}})
+        self.assertEqual(handler.deleted_attrs, {"test_model": [3]})
+        mock_get_celery_app.assert_called_once_with("test_tenant")
+        mock_redis_manager.assert_called_once()
+
+    @patch("omni.pro.webhook.webhook_handler._logger")
+    @patch(
+        "omni.pro.webhook.webhook_handler.CeleryRedis.get_celery_app_by_tenant", side_effect=Exception("Celery error")
+    )
+    def test_init_celery_app_error(self, mock_get_celery_app, mock_logger):
+        handler = WebhookHandler(self.crud_attrs, self.context)
+        self.assertIsNone(handler.celery_app)
+        mock_logger.error.assert_called_with("Celery error")
+
+    @patch("omni.pro.webhook.webhook_handler.threading.Thread.start")
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler.resolve_interface")
+    def test_start_thread(self, mock_resolve_interface, mock_thread_start):
+        WebhookHandler.start_thread(self.crud_attrs, self.context)
+
+        mock_thread_start.assert_called_once()
+
+    @patch("omni.pro.webhook.webhook_handler._logger")
+    def test_start_thread_no_tenant_or_type_db(self, mock_logger):
+        invalid_context = {"user": "test_user"}
+        WebhookHandler.start_thread(self.crud_attrs, invalid_context)
+
+        mock_logger.error.assert_called_with("Tenant or type db is not defined")
+
+    def test_resolve_interface_document(self):
+        self.handler.redis_manager = RedisManager(host="localhost", port=27017, db=0, redis_ssl=False)
+
+        self.handler.context = {"tenant": "test_tenant"}
+        self.handler.tenant = "test_tenant"
+        self.handler.type_db = "document"
+
+        try:
+            self.handler.resolve_interface()
+        except Exception as e:
+            self.fail(f"resolve_interface raised an exception: {e}")
+
+    @patch("threading.Thread.start")
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler.resolve_interface")
+    def test_start_thread(self, mock_resolve_interface, mock_thread_start):
+        crud_attrs = {
+            "created_attrs": {"some_key": [1, 2, 3]},
+        }
+        context = {
+            "tenant": "test_tenant",
+            "type_db": "sql",
+        }
+
+        WebhookHandler.start_thread(crud_attrs, context)
+
+        mock_thread_start.assert_called_once()
+
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler._set_webhooks_by_event_id")
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler._set_event_by_code")
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler._send_webhooks")
+    @patch("time.sleep", return_value=None)
+    def test_process_and_dispatch_webhooks(self, mock_sleep, mock_send_webhooks, mock_set_event, mock_set_webhooks):
+        mock_set_event.return_value = True
+        mock_set_webhooks.return_value = True
+
+        self.handler.event_by_code = {"event_1": "code_1"}
+
+        self.handler.webhooks_by_event_id = {"event_1": ["webhook_1"]}
+
+        self.handler.process_and_dispatch_webhooks()
+
+        mock_sleep.assert_called_once()
+        mock_set_event.assert_called_once()
+        mock_set_webhooks.assert_called_once()
+        mock_send_webhooks.assert_called_once()
+
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler._send_notification_webhook_records")
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler._send_external_webhook_records")
+    def test_resend_webhook_entry(self, mock_send_external, mock_send_notification):
+        webhook_entry = {"webhook": {"type_webhook": "notification"}}
+        self.handler.resend_webhook_entry(webhook_entry)
+
+        mock_send_notification.assert_called_once()
+
+        webhook_entry["webhook"]["type_webhook"] = "external"
+        self.handler.resend_webhook_entry(webhook_entry)
+
+        mock_send_external.assert_called_once()
+
+    def test_create_celery_task(self):
+        webhook_entry = {"webhook": {"name": "test_webhook", "priority_level": 2}, "records": [1, 2, 3]}
+
+        self.handler._create_celery_task(webhook_entry)
+
+        self.handler.celery_app.send_task.assert_called_once_with(
+            name="retry_send_webhook",
+            args=[webhook_entry, self.handler.context],
+            kwargs={"name": "test_webhook", "records_count": 3},
+            queue="high",
+        )
+
+    def test_resolve_interface_sql(self):
+        self.context = {"tenant": "test_tenant", "type_db": "sql"}
+
+        handler = WebhookHandler(self.crud_attrs, self.context)
+
+        try:
+            handler.resolve_interface()
+        except Exception as e:
+            self.fail(f"resolve_interface raised an exception: {e}")
+
+    @patch.object(WebhookHandler, "_send_records_to_mirror_model")
+    @patch.object(WebhookHandler, "_send_external_webhook_records")
+    @patch.object(WebhookHandler, "_send_notification_webhook_records")
+    def test_resend_webhook_entry(self, mock_send_notification, mock_send_external, mock_send_mirror):
+        handler = WebhookHandler({}, {"tenant": "test_tenant", "user": "test_user"})
+
+        webhook_entry = {"model_mirror": {"some_key": "some_value"}}
+        handler.resend_webhook_entry(webhook_entry)
+        mock_send_mirror.assert_called_once_with(webhook_entry, timeout=0)
+
+        webhook_entry = {"webhook": {"type_webhook": "external"}}
+        handler.resend_webhook_entry(webhook_entry)
+        mock_send_external.assert_called_once_with(webhook_entry, timeout=0)
+
+        webhook_entry["webhook"]["type_webhook"] = "notification"
+        handler.resend_webhook_entry(webhook_entry)
+        mock_send_notification.assert_called_once_with(webhook_entry, timeout=0)
+
+    def test_resend_webhook_entry_undefined_context(self):
+        handler = WebhookHandler({}, {})
+        webhook_entry = {}
+
+        with self.assertRaises(Exception) as context:
+            handler.resend_webhook_entry(webhook_entry)
+
+        self.assertEqual(str(context.exception), "Undefined context")
+
+    @patch("omni_pro_grpc.grpc_function.TemplateNotificationRPCFucntion.template_notification_render")
+    @patch.object(WebhookHandler, "_send_external_webhook_records")
+    @patch.object(WebhookHandler, "_create_celery_task")
+    def test_send_notification_webhook_records(self, mock_create_task, mock_send_external, mock_rpc_template):
+        handler = WebhookHandler({}, {"tenant": "test_tenant"})
+        webhook_entry = {
+            "webhook": {"template_notification": {"id": "test_template"}},
+            "records": [{"id": 1}, {"id": 2}],
+        }
+
+        mock_rpc_template.return_value = {
+            "response_standard": {"success": True},
+            "render": {1: "rendered_data_1", 2: "rendered_data_2"},
+        }
+        handler._send_notification_webhook_records(webhook_entry)
+        mock_send_external.assert_called_once()
+
+        mock_rpc_template.return_value = {"response_standard": {"success": False, "message": "Some error"}}
+        handler.send_to_queue = True
+        handler._send_notification_webhook_records(webhook_entry)
+        mock_create_task.assert_called_once()
+
+    def test_send_notification_webhook_no_template(self):
+        handler = WebhookHandler({}, {"tenant": "test_tenant"})
+        webhook_entry = {"webhook": {}, "records": [{"id": 1}, {"id": 2}]}
+
+        with self.assertRaises(Exception) as context:
+            handler._send_notification_webhook_records(webhook_entry)
+
+        self.assertEqual(str(context.exception), "Webhook without template_notification")
+
+    def test_sort_webhooks_by_priority_level(self):
+        handler = WebhookHandler({}, {"tenant": "test_tenant"})
+
+        handler.internal_webhook_records = [
+            {"webhook": {"priority_level": 2}},
+            {"webhook": {"priority_level": 1}},
+        ]
+        handler.external_webhook_records = [
+            {"webhook": {"priority_level": 3}},
+            {"webhook": {"priority_level": 2}},
+        ]
+        handler.notification_webhook_records = [
+            {"webhook": {"priority_level": 4}},
+            {"webhook": {"priority_level": 1}},
+        ]
+
+        handler._sort_webhooks_by_priority_level()
+
+        self.assertEqual(handler.internal_webhook_records[0]["webhook"]["priority_level"], 1)
+        self.assertEqual(handler.external_webhook_records[0]["webhook"]["priority_level"], 2)
+        self.assertEqual(handler.notification_webhook_records[0]["webhook"]["priority_level"], 1)
+
+    @patch("omni_pro_base.http_request.OmniRequest.make_request")
+    @patch.object(WebhookHandler, "_create_celery_task")
+    def test_send_external_webhook_records(self, mock_create_task, mock_make_request):
+        handler = WebhookHandler({}, {"tenant": "test_tenant"})
+        webhook_entry = {
+            "webhook": {"url": "http://example.com", "method": "POST", "auth_type": "Bearer", "auth": "token"},
+            "records": [{"id": 1}, {"id": 2}],
+        }
+
+        mock_make_request.return_value = MagicMock(status_code=200)
+        handler._send_external_webhook_records(webhook_entry)
+        mock_make_request.assert_called_once()
+
+        mock_make_request.side_effect = requests.exceptions.RequestException("Error")
+        handler.send_to_queue = True
+        handler._send_external_webhook_records(webhook_entry)
+        mock_create_task.assert_called_once()
+
+    def test_send_external_webhook_no_queue(self):
+        handler = WebhookHandler({}, {"tenant": "test_tenant"})
+        webhook_entry = {"webhook": {"url": "http://example.com", "method": "POST"}, "records": [{"id": 1}, {"id": 2}]}
+
+        with self.assertRaises(Exception) as context:
+            handler._send_external_webhook_records(webhook_entry)
+
+        self.assertIn("Tipo de autenticación no soportado", str(context.exception))
+
+    @patch("omni.pro.webhook.webhook_handler.MirrorModelRPCFucntion.multi_update_model")
+    def test_send_records_to_mirror_model(self, mock_multi_update_model):
+        handler = WebhookHandler({}, {"tenant": "test_tenant"})
+
+        webhook_entry = {
+            "event": {"operation": "update"},
+            "model_mirror": {"microservice": "test_service", "class_name": "test_class"},
+            "records": [{"id": 1}, {"id": 2}],
+        }
+
+        mock_multi_update_model.return_value = {"response_standard": {"success": True}}
+
+        result = handler._send_records_to_mirror_model(webhook_entry)
+
+        mock_multi_update_model.assert_called_once()
+        self.assertTrue(result)
+
+        mock_multi_update_model.return_value = {"response_standard": {"success": False, "message": "Error"}}
+        with self.assertRaises(Exception):
+            handler._send_records_to_mirror_model(webhook_entry)
+
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler._set_instances_by_model_name_and_id")
+    def test_configure_webhook_records_by_operation(self, mock_set_instances):
+        handler = WebhookHandler({}, {"tenant": "test_tenant"})
+
+        handler.event_by_code = {"test_model_create": {"operation": "create", "id": 1}}
+        handler.webhooks_by_event_id = {1: [{"type_webhook": "internal", "trigger_fields": None}]}
+        handler.instances_by_model_name_and_id = {"test_model": {1: MagicMock(id=1)}}
+
+        operation_attrs = {"test_model": {1: {"field1"}}}
+
+        handler._configure_webhook_records_by_operation(operation_attrs, "create")
+
+        self.assertEqual(len(handler.internal_webhook_records), 1)
+
+    @patch("omni.pro.webhook.webhook_handler.OmniRequest.make_request")
+    def test_send_external_webhook_records(self, mock_make_request):
+        handler = WebhookHandler({}, {"tenant": "test_tenant"})
+
+        webhook_entry = {
+            "webhook": {"url": "http://example.com", "method": "POST", "auth_type": None, "auth": None},
+            "records": [{"id": 1}, {"id": 2}],
+        }
+
+        mock_make_request.return_value.status_code = 200
+
+        result = handler._send_external_webhook_records(webhook_entry)
+
+        mock_make_request.assert_called_once_with(
+            "http://example.com",
+            "POST",
+            json=[{"id": 1}, {"id": 2}],
+            tipo_auth=None,
+            auth_params=None,
+            timeout=handler.timeout_external,
+        )
+        self.assertTrue(result)
+
+        mock_make_request.side_effect = Exception("Request Error")
+        with self.assertRaises(Exception):
+            handler._send_external_webhook_records(webhook_entry)
+
+    @patch("omni.pro.webhook.webhook_handler.json_format.MessageToDict")
+    def test_get_records_from_proto(self, mock_message_to_dict):
+        instance_mock = MagicMock()
+        instance_mock.to_proto.return_value = "proto_instance"
+        mock_message_to_dict.return_value = {"converted_record": "value"}
+
+        instances_by_id = {"1": instance_mock}
+        records = [{"id": "1"}]
+
+        result = self.handler._get_records_from_proto(records, instances_by_id)
+
+        self.assertEqual(result, [{"converted_record": "value"}])
+        instance_mock.to_proto.assert_called_once()
+        mock_message_to_dict.assert_called_once_with("proto_instance", preserving_proto_field_name=True)
+
+    def test_transforms_model_mirror_records(self):
+        model_mirror = {
+            "persistence_type": "SQL",
+            "fields": [
+                {"code": "field1", "field_aliasing": "alias1"},
+                {"code": "field2", "field_aliasing": "alias2"},
+                {"code": "field3", "field_aliasing": "alias3"},
+            ],
+        }
+
+        records = [
+            {"alias1": "value1", "alias2": "value2", "alias3": "value3"},
+            {"alias1": "value4", "alias2": "value5", "alias3": "value6"},
+        ]
+
+        with patch.object(self.handler, "_get_field_aliasing_in_mirror_model", return_value=True), patch.object(
+            self.handler, "_get_fields_in_mirror_model", return_value=model_mirror["fields"]
+        ):
+            result = self.handler._transforms_model_mirror_records(model_mirror, records)
+
+        expected = [
+            {
+                "field1": "value1",
+                "field2": "value2",
+                "field3": "value3",
+                "tenant": "test_tenant",
+                "updated_by": "test_user",
+                "created_by": "test_user",
+            },
+            {
+                "field1": "value4",
+                "field2": "value5",
+                "field3": "value6",
+                "tenant": "test_tenant",
+                "updated_by": "test_user",
+                "created_by": "test_user",
+            },
+        ]
+
+        self.assertEqual(result, expected)
+
+    def test_get_fields_in_mirror_model(self):
+        model_mirror = {
+            "fields": [
+                {"code": "field1", "field_aliasing": "alias1"},
+                {"code": "field2", "field_aliasing": "alias2"},
+                {"code": "field3.with_dot", "field_aliasing": "alias3"},
+            ]
+        }
+
+        result = self.handler._get_fields_in_mirror_model(model_mirror)
+        expected = [{"code": "field1", "field_aliasing": "alias1"}, {"code": "field2", "field_aliasing": "alias2"}]
+
+        self.assertEqual(result, expected)
+
+    def test_get_field_aliasing_in_mirror_model(self):
+        model_mirror = {
+            "fields": [
+                {"code": "field1", "field_aliasing": "alias1"},
+                {"code": "field2", "field_aliasing": "id"},
+                {"code": "field3", "field_aliasing": "code"},
+            ]
+        }
+
+        with patch.object(self.handler, "_get_fields_in_mirror_model", return_value=model_mirror["fields"]):
+            result = self.handler._get_field_aliasing_in_mirror_model(model_mirror)
+
+        expected = {"code": "field2", "field_aliasing": "id"}
+        self.assertEqual(result, expected)
+
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler._get_field_aliasing_in_mirror_model")
+    @patch("omni.pro.webhook.webhook_handler.WebhookHandler._get_fields_in_mirror_model")
+    def test_transforms_model_mirror_records_nosql(
+        self, mock_get_fields_in_mirror_model, mock_get_field_aliasing_in_mirror_model
+    ):
+        model_mirror = {
+            "persistence_type": "NO_SQL",
+            "fields": [{"code": "field1", "field_aliasing": "alias1"}, {"code": "field2", "field_aliasing": "alias2"}],
+        }
+
+        records = [{"alias1": "value1", "alias2": "value2"}]
+
+        mock_get_fields_in_mirror_model.return_value = model_mirror["fields"]
+        mock_get_field_aliasing_in_mirror_model.return_value = True
+
+        result = self.handler._transforms_model_mirror_records(model_mirror, records)
+
+        expected = [{"field1": "value1", "field2": "value2", "context": {"tenant": "test_tenant", "user": "test_user"}}]
+
+        self.assertEqual(result, expected)
+
+    def test_set_instances_by_model_name_and_id(self):
+        mock_model = MagicMock()
+        mock_instance1 = MagicMock(id=1)
+        mock_instance2 = MagicMock(id=2)
+        self.handler.session.query.return_value.filter.return_value.all.return_value = [mock_instance1, mock_instance2]
+        self.handler.class_by_name["TestModel"] = mock_model
+
+        self.handler.created_attrs = {"TestModel": {1: "attrs1", 2: "attrs2"}}
+        self.handler._set_instances_by_model_name_and_id()
+
+        expected = {"TestModel": {1: mock_instance1, 2: mock_instance2}}
+        self.assertEqual(self.handler.instances_by_model_name_and_id, expected)
+
+    def test_instances_convert_datetime_fields_to_iso(self):
+        instances = [
+            {"field1": datetime(2024, 1, 1), "field2": "value"},
+            {"field1": "no date", "field2": datetime(2024, 2, 1)},
+        ]
+        result = self.handler._instances_convert_datetime_fields_to_iso(instances)
+        expected = [
+            {"field1": "2024-01-01T00:00:00", "field2": "value"},
+            {"field1": "no date", "field2": "2024-02-01T00:00:00"},
+        ]
+        self.assertEqual(result, expected)
+
+    @patch("omni.pro.webhook.webhook_handler._logger")  # Reemplaza con la ruta correcta
+    def test_set_webhooks_by_event_id(self, mock_logger):
+        self.handler.rpc_webhook.read_webhook.return_value = (MagicMock(webhooks=[]), True, None)
+        self.handler._set_webhooks_by_event_id()
+        self.handler.rpc_webhook.read_webhook.assert_called_once()
+        self.assertEqual(self.handler.webhooks_by_event_id, {})
+
+    @patch("omni.pro.webhook.webhook_handler._logger")  # Reemplaza con la ruta correcta
+    def test_set_webhooks_by_event_id_error(self, mock_logger):
+        self.handler.rpc_webhook.read_webhook.side_effect = Exception("Error")
+        self.handler._set_webhooks_by_event_id()
+        mock_logger.error.assert_called_with("_set_webhooks_by_event_id: Error")
+
+    @patch("omni.pro.webhook.webhook_handler._logger")  # Reemplaza con la ruta correcta
+    def test_set_event_by_code(self, mock_logger):
+        self.handler.rpc_event.read_event.return_value = (MagicMock(events=[]), True, None)
+        self.handler._set_event_by_code()
+        self.handler.rpc_event.read_event.assert_called_once()
+        self.assertEqual(self.handler.event_by_code, {})
+
+    @patch("omni.pro.webhook.webhook_handler._logger")  # Reemplaza con la ruta correcta
+    def test_set_event_by_code_error(self, mock_logger):
+        self.handler.rpc_event.read_event.side_effect = Exception("Error")
+        self.handler._set_event_by_code()
+        mock_logger.error.assert_called_with("_set_event_by_code: Error")
+
+    @patch("omni.pro.webhook.webhook_handler._logger")  # Reemplaza con la ruta correcta
+    def test_set_models_mirror_by_code(self, mock_logger):
+        self.handler.rpc_model.read_model.return_value = (MagicMock(models=[]), True, None)
+        self.handler._set_models_mirror_by_code()
+        self.handler.rpc_model.read_model.assert_called_once()
+        self.assertEqual(self.handler.models_mirror_by_code, {})
+
+    @patch("omni.pro.webhook.webhook_handler._logger")  # Reemplaza con la ruta correcta
+    def test_set_models_mirror_by_code_error(self, mock_logger):
+        self.handler.rpc_model.read_model.side_effect = Exception("Error")
+        self.handler._set_models_mirror_by_code()
+        mock_logger.error.assert_called_with("_set_models_mirror_by_code: Error")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# NVOMS-2973 - Agregar unit tests para las librerías

## ref https://omnipro.atlassian.net/browse/NVOMS-2973

## Descripción
Este PR implementa las pruebas unitarias para la librería omni.pro en el proyecto.

## Cambios
- Se agregaron pruebas unitarias en todos los archivos exisitentes, cubriendo las funcionalidades principales de la librería omni.pro.

## Motivación y contexto
- Estas pruebas aseguran la correcta funcionalidad de la librería y validan su comportamiento bajo diferentes escenarios, mejorando la cobertura de código.

## Cómo se ha probado
- Se ejecutaron las pruebas unitarias agregadas para verificar que todas las funciones principales de la librería se comporten como se espera.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A