### PR TITLE
feat: Metodo que verifica si se puede escribir en crud attrs de la se…

### DIFF
--- a/omni/pro/models/base.py
+++ b/omni/pro/models/base.py
@@ -561,6 +561,9 @@ class Base:
         if hasattr(session, "context") and not session.context:
             session.context = {"tenant": instance.tenant, "user": instance.updated_by}
 
+        if not self._can_write_crud_attrs(mapper):
+            return
+
         if action == "update" and hasattr(session, "updated_attrs"):
             modified_fields = set([f"{attr.key}" for attr in state.attrs if attr.history.has_changes()])
             if modified_fields:
@@ -579,6 +582,13 @@ class Base:
             if not model_name in session.deleted_attrs:
                 session.deleted_attrs[model_name] = []
             session.deleted_attrs[model_name].append(instance_id)
+
+    def _can_write_crud_attrs(self, mapper) -> bool:
+        table_name = mapper.mapped_table.name
+        can_write = True
+        if table_name == "sale" and hasattr(self, "client_id") and not self.client_id:
+            can_write = False
+        return can_write
 
     @classmethod
     def dt_to_ts(cls, dt) -> Timestamp:


### PR DESCRIPTION
#NVOMS-3026 No permitir enviar attrs al webhook si en ventas el client_id no esta definido

## ref 
https://omnipro.atlassian.net/browse/NVOMS-3026


## Descripción
Se ha creado un método en la biblioteca que verifica si la instancia de sale no tiene asignado el campo client_id. En caso de que el campo no esté presente, el método impedirá la escritura de los atributos CRUD en SQLAlchemy y evitará el envío de datos al webhook


## Cambios


## Motivación y contexto
Evitar errores por falta de campos en sale
## Cómo se ha probado


## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [x] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
<Información adicional o notas que los revisores deben tener en cuenta>