### PR TITLE
NVOMS-3015 - Automitizar el depsligue de Register model Apigateway al desplegar

### DIFF
--- a/omni/pro/descriptor.py
+++ b/omni/pro/descriptor.py
@@ -127,6 +127,7 @@ class Descriptor(object):
                 "name": model.__name__,
                 "class_name": f"{model.__module__}.{model.__name__}",
                 "code": model._meta.get("collection") or model.__name__.lower(),
+                "verbose_name": model._meta.get("verbose_name"),
                 "fields": fields,
             }
             if hasattr(model, "__is_replic_table__"):
@@ -172,6 +173,7 @@ class Descriptor(object):
             "name": model.__name__,
             "class_name": f"{model.__module__}.{model.__name__}",
             "code": mapper.mapped_table.name,
+            "verbose_name": model.__verbose_name__ if hasattr(model, "__verbose_name__") else None,
             "fields": [],
             "is_replic": model.__is_replic_table__,
         }


### PR DESCRIPTION
# NVOMS-3015 - Automitizar el depsligue de Register model Apigateway al desplegar

## ref https://omnipro.atlassian.net/browse/NVOMS-3015

## Descripción
Este PR define el "verbose_name" en el register model.

## Cambios
- Se agrego el campo "verbose_name" en los register models, tanto de mongo como de sqlachemy.

## Motivación y contexto
- Es necesraio para que front sepa como se devuelve la data al hacer un get.

## Cómo se ha probado
- Se ejecutaron pruebas desde la libreria.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A