### PR TITLE
feat: convert items to db type column

### DIFF
--- a/omni/pro/mirror_model.py
+++ b/omni/pro/mirror_model.py
@@ -238,6 +238,30 @@ class MirrorModelSQL(MirrorModelBase):
             raise Exception(f"tenant or unique_field_aliasing is not defined")
 
     def _convert_fields_to_db_types(self, items: list[dict]):
+        """
+        Converts specific fields in a list of items (dictionaries) to match their
+        respective database types as defined in the model's schema.
+
+        This method inspects the model to identify columns that require type conversion
+        (currently supporting `INTEGER` type) and applies the necessary transformation to
+        corresponding fields in each item in the `items` list.
+
+        Parameters:
+        ----------
+        items : list[dict]
+            A list of dictionaries, where each dictionary represents an item containing
+            fields that may need to be converted to the expected database type.
+
+        Internal Logic:
+        ---------------
+        - Uses SQLAlchemy's `inspect` to retrieve the model's columns and their types.
+        - Constructs a `field_type_by_name` dictionary mapping field names to their types
+          for fields that require conversion (currently `INTEGER`).
+        - For each item in `items`, it:
+          - Checks if the field exists in the item.
+          - Converts fields of type `INTEGER` to `int`.
+
+        """
         field_type_by_name = {}
         mapper = inspect(self.model)
         for column in mapper.columns:
@@ -450,6 +474,29 @@ class MirrorModelNoSQL(MirrorModelBase):
             raise Exception(f"tenant or unique_field_aliasing is not defined")
 
     def _convert_fields_to_db_types(self, items: list[dict]):
+        """
+        Converts specific fields in a list of items (dictionaries) to their respective
+        database types based on the model's field definitions.
+
+        This method iterates over each item in the `items` list and updates fields
+        based on the expected types defined in `self.model._fields`. It currently
+        supports conversion for fields of type `ReferenceField` and `IntField`.
+
+        Parameters:
+        ----------
+        items : list[dict]
+            A list of dictionaries, where each dictionary represents an item with
+            fields that may need to be converted to match the database type.
+
+        Internal Logic:
+        ---------------
+        - Constructs a `field_type_by_name` dictionary based on `self.model._fields`
+          that maps each field name to its type (`ReferenceField` or `IntField`).
+        - For each item in `items`, it:
+          - Checks if the field exists in the item.
+          - Converts `ReferenceField` fields to `ObjectId`.
+          - Converts `IntField` fields to `int`.
+        """
         field_type_by_name = {}
         for field_name in self.model._fields:
             field = self.model._fields.get(field_name)


### PR DESCRIPTION
# NVOMS-3047 - Convertir registros de espejos a sus tipos en la bd

## ref https://omnipro.atlassian.net/browse/NVOMS-3047

## Descripción
Se añade funcionalidad para convertir los datos que se van a poblar en los espejos al tipo que se definio en el campo

## Cambios


## Motivación y contexto
- Los servicios grpc convierten los enteros en campos flotantes lo cual estaba haciendo que no se poblaran correctamente en los espejos

## Cómo se ha probado
- Postman

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [*] Bug fix (cambios que solucionan un problema)
- [] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [*] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A