### PR TITLE
feat: add field active to mirror model data

### DIFF
--- a/omni/pro/webhook/webhook_handler.py
+++ b/omni/pro/webhook/webhook_handler.py
@@ -540,6 +540,8 @@ class WebhookHandler:
                                     trigger_fields = set(
                                         [attr.split("-", 1)[-1] for attr in webhook.get("trigger_fields")]
                                     )
+                                    if not "active" in trigger_fields:
+                                        trigger_fields.add("active")
                                     filter_records = []
                                     for record in records:
                                         record_id = record.get("id")
@@ -601,6 +603,8 @@ class WebhookHandler:
                 for field in fields:
                     field_aliasing = field.get("field_aliasing")
                     field_code = field.get("code")
+                    if not field_aliasing and field_code == "active":
+                        field_aliasing = field_code
                     if field_aliasing:
                         field_value = nested(record, field_aliasing)
                         if isinstance(field_value, datetime):
@@ -627,7 +631,7 @@ class WebhookHandler:
         return [
             field
             for field in mirror_model.get("fields")
-            if "field_aliasing" in field and not ("." in field.get("code"))
+            if ("field_aliasing" in field or field.get("code") == "active") and not ("." in field.get("code"))
         ]
 
     def _get_field_aliasing_in_mirror_model(self, model_mirror):


### PR DESCRIPTION
# NVOMS-3058 - En los webhooks tipo internos poblar campo active a espejo

## ref https://omnipro.atlassian.net/browse/NVOMS-3058

## Descripción
Este PR añade el campo active por defecto a los triggers y  fields values hacia los espejos

## Cambios
- 

## Motivación y contexto
- No se estaba poblando el campo active

## Cómo se ha probado


## Screenshots (si aplica)
N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A