### PR TITLE
Fix Enum option name conversion to ensure proper string representation in descriptor

### DIFF
--- a/omni/pro/descriptor.py
+++ b/omni/pro/descriptor.py
@@ -106,7 +106,7 @@ class Descriptor(object):
 
             # if the field is an Enum, add options values
             if hasattr(field, "choices") and field.choices:
-                field_info["options"] = [{"code": x.value, "name": to_camel_case(x.value)} for x in field.choices]
+                field_info["options"] = [{"code": x.value, "name": to_camel_case(str(x.value))} for x in field.choices]
 
             fields.append(field_info)
 


### PR DESCRIPTION
#  excepción al arrancar el servicio de Utilidades

## ref <número de ticket jira + enlace>
https://omnipro.atlassian.net/browse/NVOMS-3127

## Descripción
Parsear value a un str para la función `to_camel_case`

## Cambios
- Parseo de x.value

## Motivación y contexto
Enum value es un int, y la función `to_camel_case` solo recibe str

## Cómo se ha probado
<Descripción de las pruebas que se han realizado para verificar los cambios>
- Corriendo register_model

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [ ] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [ ] Mi código sigue las directrices de estilo de este proyecto
- [ ] He realizado una auto-revisión de mi propio código
- [ ] He comentado mi código, especialmente en áreas difíciles de entender
- [ ] He hecho cambios correspondientes en la documentación
- [ ] Mis cambios no generan nuevas advertencias
- [ ] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [ ] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [ ] Debería ser revisado por al menos un desarrollador más antes de fusionarse

