### PR TITLE
Add fallback to retrieve 'id' field in MirrorModelSQL 

### DIFF
--- a/omni/pro/mirror_model.py
+++ b/omni/pro/mirror_model.py
@@ -291,6 +291,7 @@ class MirrorModelSQL(MirrorModelBase):
                             ),
                             None,
                         )
+                        # If the related model is not a replic table, try to find the id field
                         if related_field is None and not model_dest.__is_replic_table__:
                             related_field = next(
                                 filter(

--- a/omni/pro/mirror_model.py
+++ b/omni/pro/mirror_model.py
@@ -291,6 +291,15 @@ class MirrorModelSQL(MirrorModelBase):
                             ),
                             None,
                         )
+                        if related_field is None and not model_dest.__is_replic_table__:
+                            related_field = next(
+                                filter(
+                                    lambda x: x.name == "id",
+                                    model_dest.__table__.columns,
+                                ),
+                                None,
+                            )
+
                         if related_field is None:
                             raise OmniStopIteration(
                                 f"Model destination {model_dest} does not have a field with field_aliasing id - model: {self.model} - column: {column} - fk: {fk}"


### PR DESCRIPTION
# BUG: Carrier no actualiza en Sale cuando se actualiza en Stock (espejos)

## ref <número de ticket jira + enlace>
https://omnipro.atlassian.net/browse/NVOMS-2543


## Descripción
related_field quedaba en None, ya que el modelo destino NO era una replica, lo que hacía que quedara en None,
model_dest era un Modelo Original, y este no cuenta con field_aliasing, entonces se utiliza el ID para los modelos Originales

## Motivación y contexto
model_dest era un Modelo Original, y este no cuenta con field_aliasing, no actualizaba las replicas 

## Tipo de cambio
- [x] Bug fix (cambios que solucionan un problema)
- [ ] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [ ] Mi código sigue las directrices de estilo de este proyecto
- [ ] He realizado una auto-revisión de mi propio código
- [ ] He comentado mi código, especialmente en áreas difíciles de entender
- [ ] He hecho cambios correspondientes en la documentación
- [ ] Mis cambios no generan nuevas advertencias
- [ ] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [ ] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [ ] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
<Información adicional o notas que los revisores deben tener en cuenta>