### PR TITLE
NVOMS-3135- Tomar la data de HTML, interpretar y rellenarla como corresponda

### DIFF
--- a/omni/pro/mirror_model.py
+++ b/omni/pro/mirror_model.py
@@ -708,6 +708,14 @@ class MirrorModelServiceMongo(mirror_model_pb2_grpc.MirrorModelServiceServicer):
                     request.id, request.fields, request.filter, request.paginated, None, request.sort_by
                 )
                 result = base.read_mirror_model(request.context.tenant, data)
+                if request.protobuf:
+                    return message_response.created_response(
+                        message="Mirror model read successfully",
+                        mirror_models=to_list_value(
+                            [MessageToDict(mirror_model.to_proto()) for mirror_model in result]
+                        ),
+                    )
+
                 return message_response.created_response(
                     message="Mirror model read successfully",
                     mirror_models=to_list_value([mirror_model.generate_dict() for mirror_model in result[0]]),


### PR DESCRIPTION
# NVOMS-3135- Tomar la data de HTML, interpretar y rellenarla como corresponda

## ref NVOMS-3135 https://omnipro.atlassian.net/browse/NVOMS-3135

## Descripción
- Este PR agrega el campo protobuf de tipo booleano.
- Este PR agrega el texto de ayuda en los BaseDocument.
- Este PR realiza mejoras en el register_models.

## Cambios
- Añadido el campo protobuf de tipo booleano para saber como devolver la respuesta en el read del mirror_model.
- Añadidos los textos de ayudas en los campos de los Modelos bases tanto para SQL como NO_SQL.
- Se ajustaron como se estaban registrando las relaciones de los documentos de mongo en model.

## Motivación y contexto
Estos cambios son necesarios para devolver todo el to_proto del modelo y asi devolver el objeto completo de las relaciones que ese modelo tenga y mejorar el registro de modelos.

## Cómo se ha probado
-  Se realizaron pruebas compilando la nueva versión de la librería.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [x] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A