### PR TITLE
NVOMS-3153- Instanciar los filds de la base de datos de DB

### DIFF
--- a/omni/pro/database/postgres.py
+++ b/omni/pro/database/postgres.py
@@ -359,7 +359,11 @@ class PostgresDatabaseManager(SessionManager):
         offset = (page - 1) * limit
         query = query.offset(offset).limit(limit)
 
-        return query.all(), total
+        results = query.all()
+        if fields.ListFields():
+            results = [model(**dict(zip(fields.name_field, record))) for record in results]
+            
+        return results, total
 
     def build_sort_by(self, model, sort_by: base_pb2.SortBy):
         field = getattr(model, sort_by.name_field)


### PR DESCRIPTION
# NVOMS-3153- Instanciar los filds de la base de datos de DB

## ref NVOMS-3153 https://omnipro.atlassian.net/browse/NVOMS-3153

## Descripción
- Este PR agrega una condición para devolver el resultado en objeto, si el get viene con fields.

## Cambios
- Agrega una condición para devolver el resultado en objeto, si el get viene con fields.

## Motivación y contexto
Estos cambios son necesarios para solventar error al hacer un get com fields en los microservicios que utilizand postgres como base de datos.

## Cómo se ha probado
-  Se realizaron pruebas con el cleinte grpc.

## Screenshots (si aplica)
N/A

## Tipo de cambio
- [x]  Bug fix (cambios que solucionan un problema)
- [ ] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
N/A