### PR TITLE
Fix convert_name_upper_snake_case to return correct action order in generated string

### DIFF
--- a/omni/pro/decorators.py
+++ b/omni/pro/decorators.py
@@ -112,7 +112,7 @@ def convert_name_upper_snake_case(function_name: str, model_name: str) -> str:
     if set(model_name.split("_")).intersection(set(components)):
         resul = [component for component in components if component not in model_name.split("_")]
         action = "_".join(resul)
-        return f"CAN_{action}_{model_name}".upper()
+        return f"CAN_{model_name}_{action}".upper()
     return f"CAN_{snake_case}".upper()
 
 


### PR DESCRIPTION
# 10. Ajustar la funcionalidad de evaluar permisos de usuarios

## ref https://omnipro.atlassian.net/browse/NVOMS-2984

## Descripción
Se ajusto el nombre del permiso, ya que estaba quedando de la siguiente manera

CAN_READ_TIMEZONE, cuando en la nueva forma el método va al final, CAN_TIMEZONE_READ
ver los permisos del manifiesto de los micros para validar esta info


## Motivación y contexto
Nombre del permiso mal formateado 

## Tipo de cambio
- [x] Bug fix (cambios que solucionan un problema)
- [ ] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [ ] He comentado mi código, especialmente en áreas difíciles de entender
- [ ] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [ ] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
<Información adicional o notas que los revisores deben tener en cuenta>