### PR TITLE
fix : nombre del permiso

### DIFF
--- a/omni/pro/decorators.py
+++ b/omni/pro/decorators.py
@@ -72,9 +72,7 @@ def resources_decorator(
 
 def permission_required(rm: RedisManager, request, funcion: callable, message_response, permission_code: str):
     try:
-        permission = permission_code or convert_name_upper_snake_case(
-            funcion.__name__, funcion.__module__.split(".")[-1].upper()
-        )
+        permission = permission_code or convert_name_upper_snake_case(funcion.__name__)
         config = rm.get_resource_config(Config.SAAS_MS_USER, request.context.tenant)
         rds_conn = nested(config, "dbs.redis")
         rm_per = RedisManager(**rds_conn)
@@ -102,18 +100,9 @@ def permission_required(rm: RedisManager, request, funcion: callable, message_re
         return MessageResponse(message_response).internal_response(message="Permission required decorator exception")
 
 
-def convert_name_upper_snake_case(function_name: str, model_name: str) -> str:
-    snake = re.sub(r"([A-Z])", r"_\1", function_name).lower()
-    # Eliminar el guión bajo inicial si existe y convertir todo a mayúsculas
-    snake_case = (snake[1:] if snake.startswith("_") else snake).upper()
-    components = snake_case.split("_")
-
-    # Identificar la acción y el modelo
-    if set(model_name.split("_")).intersection(set(components)):
-        resul = [component for component in components if component not in model_name.split("_")]
-        action = "_".join(resul)
-        return f"CAN_{model_name}_{action}".upper()
-    return f"CAN_{snake_case}".upper()
+def convert_name_upper_snake_case(function_name: str) -> str:
+    snake_case = re.sub(r"(?<!^)(?=[A-Z])", "_", function_name).upper()
+    return f"CAN_{snake_case}"
 
 
 class FunctionThreadController:


### PR DESCRIPTION
## Ajuste de Permisos en Manifiestos y captura de Error

## ref https://omnipro.atlassian.net/browse/NVOMS-3222

## Descripción
Este pull request aborda la corrección en la generación del nombre del permiso para los decoradores, simplificando la función de conversión y asegurando que el `permission_code` se asigne correctamente a partir del nombre de la función.

## Cambios
- Se elimina la lógica antigua en `convert_name_upper_snake_case` que incluía `model_name`.
- Se simplifica la función a una sola responsabilidad, generando el permiso a partir del nombre de la función.
- Se ajusta la línea de asignación a `permission = permission_code or convert_name_upper_snake_case(function.__name__)`.
- Se elimina el código no utilizado y comentarios obsoletos.

## Motivación y contexto
Estos cambios son necesarios para estandarizar la forma en que se genera el nombre del permiso y evitar ambigüedades en la lógica. Además, reduce la complejidad en la definición de los decoradores y facilita la mantención futura del código.

## Cómo se ha probado
- Pruebas manuales invocando endpoints protegidos para verificar el correcto manejo de permisos.

## Tipo de cambio
- [x] Bug fix (cambios que solucionan un problema)
- [ ] Nueva característica (cambios que añaden funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [ ] He hecho cambios correspondientes en la documentación
- [ ] Mis cambios no generan nuevas advertencias
- [ ] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [ ] Debería ser revisado por al menos un desarrollador más antes de fusionarse
